### PR TITLE
Fixed an error that did not exist in the table in odp mode

### DIFF
--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTestLoadTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTestLoadTest.java
@@ -77,8 +77,12 @@ public class OHTableClientTestLoadTest extends HTableTestBase {
             while (t.getCause() != null) {
                 t = t.getCause();
             }
-            Assert.assertTrue(t instanceof ObTableNotExistException);
-            Assert.assertTrue(t.getMessage().contains("test_t$testload"));
+            if (ObHTableTestUtil.ODP_MODE) {
+                Assert.assertTrue(t instanceof ObTableUnexpectedException);
+            } else {
+                Assert.assertTrue(t instanceof ObTableNotExistException);
+                Assert.assertTrue(t.getMessage().contains("test_t$testload"));
+            }
         }
         hTable.getConfiguration().set(HBASE_HTABLE_TEST_LOAD_SUFFIX, "_a");
         try {
@@ -90,8 +94,12 @@ public class OHTableClientTestLoadTest extends HTableTestBase {
             while (t.getCause() != null) {
                 t = t.getCause();
             }
-            Assert.assertTrue(t instanceof ObTableNotExistException);
-            Assert.assertTrue(t.getMessage().contains("test_a$testload"));
+            if (ObHTableTestUtil.ODP_MODE) {
+                Assert.assertTrue(t instanceof ObTableUnexpectedException);
+            } else {
+                Assert.assertTrue(t instanceof ObTableNotExistException);
+                Assert.assertTrue(t.getMessage().contains("test_a$testload"));
+            }
         }
     }
 }

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTablePoolLoadTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTablePoolLoadTest.java
@@ -18,6 +18,7 @@
 package com.alipay.oceanbase.hbase;
 
 import com.alipay.oceanbase.rpc.exception.ObTableNotExistException;
+import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HTableInterface;
@@ -91,8 +92,12 @@ public class OHTablePoolLoadTest extends HTableTestBase {
             while (t.getCause() != null) {
                 t = t.getCause();
             }
-            Assert.assertTrue(t instanceof ObTableNotExistException);
-            Assert.assertTrue(t.getMessage().contains("test_t$testload"));
+            if (ObHTableTestUtil.ODP_MODE) {
+                Assert.assertTrue(t instanceof ObTableUnexpectedException);
+            } else {
+                Assert.assertTrue(t instanceof ObTableNotExistException);
+                Assert.assertTrue(t.getMessage().contains("test_t$testload"));
+            }
         }
         hTable.getConfiguration().set(HBASE_HTABLE_TEST_LOAD_SUFFIX, "_a");
         try {
@@ -103,8 +108,12 @@ public class OHTablePoolLoadTest extends HTableTestBase {
             while (t.getCause() != null) {
                 t = t.getCause();
             }
-            Assert.assertTrue(t instanceof ObTableNotExistException);
-            Assert.assertTrue(t.getMessage().contains("test_a$testload"));
+            if (ObHTableTestUtil.ODP_MODE) {
+                Assert.assertTrue(t instanceof ObTableUnexpectedException);
+            } else {
+                Assert.assertTrue(t instanceof ObTableNotExistException);
+                Assert.assertTrue(t.getMessage().contains("test_a$testload"));
+            }
         }
 
         hTable.getConfiguration().set(HBASE_HTABLE_TEST_LOAD_ENABLE, "false");


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
To handle the difference in error reporting between ODP mode and direct mode when a table does not exist, add a check for ODP mode when the table does not exist.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
By adding a judgment for ODP mode, the two expected errors are differentiated.