### PR TITLE
[Fix] the cell's timestamp of the Get result is always int64_max

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -393,7 +393,8 @@ public class OHTable implements HTableInterface {
             KeyValue kv = new KeyValue((byte[]) row.get(0).getValue(),//K
                 familyAndQualifier[0], // family
                 familyAndQualifier[1], // qualifier
-                (byte[]) row.get(3).getValue()//T
+                (Long) row.get(2).getValue(), // T
+                (byte[]) row.get(3).getValue()//  V
             );
             keyValueList.add(kv);
         }

--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -73,6 +73,10 @@ public abstract class HTableTestBase {
         Result r = hTable.get(get);
         Assert.assertEquals(1, r.raw().length);
         for (KeyValue keyValue : r.raw()) {
+            Assert.assertEquals(key, Bytes.toString(keyValue.getRow()));
+            Assert.assertEquals(column1, Bytes.toString(keyValue.getQualifier()));
+            Assert.assertEquals(timestamp, keyValue.getTimestamp());
+            Assert.assertEquals(value + "1", Bytes.toString(keyValue.getValue()));
             System.out.println("rowKey: " + new String(keyValue.getRow()) + " family :"
                                + new String(keyValue.getFamily()) + " columnQualifier:"
                                + new String(keyValue.getQualifier()) + " timestamp:"
@@ -86,6 +90,10 @@ public abstract class HTableTestBase {
         r = hTable.get(get);
         Assert.assertEquals(1, r.raw().length);
         for (KeyValue keyValue : r.raw()) {
+            Assert.assertEquals(key, Bytes.toString(keyValue.getRow()));
+            Assert.assertEquals(column1, Bytes.toString(keyValue.getQualifier()));
+            Assert.assertEquals(timestamp, keyValue.getTimestamp());
+            Assert.assertEquals(value + "1", Bytes.toString(keyValue.getValue()));
             System.out.println("rowKey: " + new String(keyValue.getRow()) + " family :"
                                + new String(keyValue.getFamily()) + " columnQualifier:"
                                + new String(keyValue.getQualifier()) + " timestamp:"
@@ -98,6 +106,10 @@ public abstract class HTableTestBase {
         ResultScanner scanner = hTable.getScanner(scan);
         for (Result result : scanner) {
             for (KeyValue keyValue : result.raw()) {
+                Assert.assertEquals(key, Bytes.toString(keyValue.getRow()));
+                Assert.assertEquals(column1, Bytes.toString(keyValue.getQualifier()));
+                Assert.assertEquals(timestamp, keyValue.getTimestamp());
+                Assert.assertEquals(value + "1", Bytes.toString(keyValue.getValue()));
                 System.out.println("rowKey: " + new String(keyValue.getRow()) + " family :"
                                    + new String(keyValue.getFamily()) + " columnQualifier:"
                                    + new String(keyValue.getQualifier()) + " timestamp:"
@@ -135,7 +147,9 @@ public abstract class HTableTestBase {
                                + new String(keyValue.getQualifier()) + " timestamp:"
                                + keyValue.getTimestamp() + " value:"
                                + new String(keyValue.getValue()));
+            Assert.assertEquals(key, Bytes.toString(keyValue.getRow()));
             Assert.assertEquals(column1, Bytes.toString(keyValue.getQualifier()));
+            Assert.assertEquals(timestamp, keyValue.getTimestamp());
             Assert.assertEquals(value, Bytes.toString(keyValue.getValue()));
         }
 
@@ -161,15 +175,17 @@ public abstract class HTableTestBase {
                                + new String(keyValue.getQualifier()) + " timestamp:"
                                + keyValue.getTimestamp() + " value:"
                                + new String(keyValue.getValue()));
+            Assert.assertEquals(key, Bytes.toString(keyValue.getRow()));
             Assert.assertEquals(column1, Bytes.toString(keyValue.getQualifier()));
+            Assert.assertEquals(timestamp + 1, keyValue.getTimestamp());
             Assert.assertEquals(value, Bytes.toString(keyValue.getValue()));
         }
 
         try {
             for (int j = 0; j < 10; j++) {
                 put = new Put((key + "_" + j).getBytes());
-                put.add(family.getBytes(), column1.getBytes(), toBytes(value));
-                put.add(family.getBytes(), column2.getBytes(), toBytes(value));
+                put.add(family.getBytes(), column1.getBytes(), timestamp + 2, toBytes(value));
+                put.add(family.getBytes(), column2.getBytes(), timestamp + 2, toBytes(value));
                 hTable.put(put);
             }
 
@@ -178,7 +194,7 @@ public abstract class HTableTestBase {
             scan.addColumn(family.getBytes(), column2.getBytes());
             scan.setStartRow(toBytes(key + "_" + 0));
             scan.setStopRow(toBytes(key + "_" + 9));
-            scan.setMaxVersions(9);
+            scan.setMaxVersions(1);
             ResultScanner scanner = hTable.getScanner(scan);
             int i = 0;
             int count = 0;
@@ -192,6 +208,7 @@ public abstract class HTableTestBase {
                     Assert.assertEquals(key + "_" + i, Bytes.toString(keyValue.getRow()));
                     Assert.assertTrue(column1.equals(Bytes.toString(keyValue.getQualifier()))
                                       || column2.equals(Bytes.toString(keyValue.getQualifier())));
+                    Assert.assertEquals(timestamp + 2, keyValue.getTimestamp());
                     Assert.assertEquals(value, Bytes.toString(keyValue.getValue()));
                     if (countAdd) {
                         countAdd = false;
@@ -205,6 +222,7 @@ public abstract class HTableTestBase {
 
             // scan.setBatch(1);
 
+            scan.setMaxVersions(9);
             scanner = hTable.getScanner(scan);
             i = 0;
             count = 0;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
 the cell's timestamp of the Get result is always int64_max
## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
instead of using the default timestamp value which is int64_max, constructing the cell using the result row's timestamp value
