### PR TITLE
[Fix] checkAndMutate and get/Scan with filter return -5006 when include special character

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -1218,23 +1218,15 @@ public class OHTable implements HTableInterface {
 
     private byte[] buildCheckAndMutateFilterString(byte[] family, byte[] qualifier, byte[] value) throws IOException {
         ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        byteStream.write("CheckAndMutateFilter(=, 'binary:".getBytes());
+        writeBytesWithEscape(byteStream, value);
+        byteStream.write("', '".getBytes());
+        writeBytesWithEscape(byteStream, family);
+        byteStream.write("', '".getBytes());
+        writeBytesWithEscape(byteStream, qualifier);
         if (value != null) {
-            byteStream.write("CheckAndMutateFilter(=, 'binary:".getBytes());
-            writeBytesWithEscape(byteStream, value);
-            byteStream.write("', '".getBytes());
-            writeBytesWithEscape(byteStream, family);
-            byteStream.write("', '".getBytes());
-            if (qualifier != null) {
-                writeBytesWithEscape(byteStream, qualifier);
-            }
             byteStream.write("', false)".getBytes());
         } else {
-            byteStream.write("CheckAndMutateFilter(=, 'binary:', '".getBytes());
-            writeBytesWithEscape(byteStream, family);
-            byteStream.write("', '".getBytes());
-            if (qualifier != null) {
-                writeBytesWithEscape(byteStream, qualifier);
-            }
             byteStream.write("', true)".getBytes());
         }
         return byteStream.toByteArray();

--- a/src/main/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtils.java
@@ -217,6 +217,9 @@ public class HBaseFilterUtils {
     // when write family/qualifier/value/row into hbase filter, need add escape for
     // special character to prevent parse error in server
     public static void writeBytesWithEscape(ByteArrayOutputStream byteStream, byte[] bytes) throws IOException {
+        if (bytes == null) {
+            return;
+        }
         for (int i = 0; i < bytes.length; i++) {
             if (bytes[i] == '\'') {
                 byteStream.write('\'');

--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
 
 import static org.apache.hadoop.hbase.filter.FilterList.Operator.MUST_PASS_ONE;
@@ -2543,5 +2544,62 @@ public abstract class HTableTestBase {
     @Test
     public void testHtableWithIndex() throws Exception {
         testBasic("family_with_local_index");
+    }
+
+    @Test
+    public void testFilterSpecialValue() throws IOException {
+        // 1. test checkAndMutate with special character
+        String specialValue = "AAEAAAGRnJiQbwAAAZGcmJwndjE=";
+        byte[] specialBytes = Base64.getDecoder().decode(specialValue);
+        String family = "family'1";
+        byte[] keyBytes = specialBytes;
+        byte[] columnBytes = specialBytes;
+        byte[] valueBytes = specialBytes;
+
+        Delete delete = new Delete(keyBytes);
+        delete.deleteFamily(family.getBytes());
+        hTable.delete(delete);
+
+        Put put = new Put(keyBytes);
+        put.add(family.getBytes(), columnBytes, valueBytes);
+        hTable.put(put);
+
+        // check delete column
+        delete = new Delete(keyBytes);
+        delete.deleteColumn(family.getBytes(), columnBytes);
+        boolean ret = hTable.checkAndDelete(keyBytes, family.getBytes(), columnBytes,
+                valueBytes, delete);
+        Assert.assertTrue(ret);
+
+        // 2. test normal filter with special chracter
+        put = new Put(keyBytes);
+        put.add(family.getBytes(), columnBytes, valueBytes);
+        hTable.put(put);
+
+
+        Get get = new Get(keyBytes);
+        get.addFamily(family.getBytes());
+        // 2.1 test special row
+        RowFilter rowFilter = new RowFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(keyBytes));
+        get.setFilter(rowFilter);
+        Result result = hTable.get(get);
+        Assert.assertEquals(1, result.raw().length);
+        Assert.assertArrayEquals(keyBytes, result.getRow());
+
+        // 2.2 test special column
+        SingleColumnValueFilter singleColumnValueFilter = new SingleColumnValueFilter(family.getBytes(),
+                columnBytes, CompareFilter.CompareOp.EQUAL, valueBytes);
+        get.setFilter(singleColumnValueFilter);
+        result = hTable.get(get);
+        Assert.assertEquals(1, result.raw().length);
+        Assert.assertArrayEquals(keyBytes, result.getRow());
+
+        // 2.3 test special value
+        ValueFilter valueFilter = new ValueFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(valueBytes));
+        get.setFilter(valueFilter);
+        result = hTable.get(get);
+        Assert.assertEquals(1, result.raw().length);
+        Assert.assertArrayEquals(keyBytes, result.getRow());
+
     }
 }

--- a/src/test/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtilsTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtilsTest.java
@@ -22,6 +22,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.IOException;
+
 public class HBaseFilterUtilsTest {
     private static final CompareFilter.CompareOp[] ops     = { CompareFilter.CompareOp.LESS,
             CompareFilter.CompareOp.LESS_OR_EQUAL, CompareFilter.CompareOp.EQUAL,
@@ -35,135 +37,135 @@ public class HBaseFilterUtilsTest {
     }
 
     @Test
-    public void testRowFilter() {
+    public void testRowFilter() throws IOException {
         for (int i = 0; i < ops.length; i++) {
             RowFilter filter = new RowFilter(ops[i], new BinaryComparator(
                 "testRowFilter".getBytes()));
             String expect = String.format("RowFilter(%s,'binary:testRowFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new BinaryPrefixComparator("testRowFilter".getBytes()));
             expect = String.format("RowFilter(%s,'binaryprefix:testRowFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new RegexStringComparator("testRowFilter"));
             expect = String.format("RowFilter(%s,'regexstring:testRowFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new SubstringComparator("testRowFilter"));
             expect = String.format("RowFilter(%s,'substring:testrowfilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
     @Test
-    public void testValueFilter() {
+    public void testValueFilter() throws IOException {
         for (int i = 0; i < ops.length; i++) {
             ValueFilter filter = new ValueFilter(ops[i], new BinaryComparator(
                 "testValueFilter".getBytes()));
             String expect = String.format("ValueFilter(%s,'binary:testValueFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new BinaryPrefixComparator(
                 "testValueFilter".getBytes()));
             expect = String.format("ValueFilter(%s,'binaryprefix:testValueFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new RegexStringComparator("testValueFilter"));
             expect = String.format("ValueFilter(%s,'regexstring:testValueFilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new SubstringComparator("testValueFilter"));
             expect = String.format("ValueFilter(%s,'substring:testvaluefilter')", opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
     @Test
-    public void testQualifierFilter() {
+    public void testQualifierFilter() throws IOException {
         for (int i = 0; i < ops.length; i++) {
             QualifierFilter filter = new QualifierFilter(ops[i], new BinaryComparator(
                 "testQualifierFilter".getBytes()));
             String expect = String.format("QualifierFilter(%s,'binary:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new BinaryPrefixComparator(
                 "testQualifierFilter".getBytes()));
             expect = String.format("QualifierFilter(%s,'binaryprefix:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new RegexStringComparator("testQualifierFilter"));
             expect = String.format("QualifierFilter(%s,'regexstring:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new SubstringComparator("testQualifierFilter"));
             expect = String.format("QualifierFilter(%s,'substring:testqualifierfilter')",
                 opFlags[i]);
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
     @Test
-    public void testSingleColumnValueFilter() {
+    public void testSingleColumnValueFilter() throws IOException {
         for (int i = 0; i < ops.length; i++) {
             String expect = String.format(
                 "SingleColumnValueFilter('family','qualifier',%s,'binary:value',false,true)",
                 opFlags[i]);
             SingleColumnValueFilter filter = new SingleColumnValueFilter("family".getBytes(),
                 "qualifier".getBytes(), ops[i], "value".getBytes());
-            Assert.assertEquals(expect, HBaseFilterUtils.toParseableString(filter));
+            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
     @Test
-    public void testPageFilter() {
+    public void testPageFilter() throws IOException {
         PageFilter filter = new PageFilter(128);
-        Assert.assertEquals("PageFilter(128)", HBaseFilterUtils.toParseableString(filter));
+        Assert.assertArrayEquals("PageFilter(128)".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testColumnPaginationFilter() {
+    public void testColumnPaginationFilter() throws IOException {
         ColumnPaginationFilter filter = new ColumnPaginationFilter(2, 2);
-        Assert.assertEquals("ColumnPaginationFilter(2,2)",
-            HBaseFilterUtils.toParseableString(filter));
+        Assert.assertArrayEquals("ColumnPaginationFilter(2,2)".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testColumnCountGetFilter() {
+    public void testColumnCountGetFilter() throws IOException {
         ColumnCountGetFilter filter = new ColumnCountGetFilter(513);
-        Assert
-            .assertEquals("ColumnCountGetFilter(513)", HBaseFilterUtils.toParseableString(filter));
+        Assert.assertArrayEquals("ColumnCountGetFilter(513)".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testPrefixFilter() {
+    public void testPrefixFilter() throws IOException {
         PrefixFilter filter = new PrefixFilter("prefix".getBytes());
-        Assert.assertEquals("PrefixFilter('prefix')", HBaseFilterUtils.toParseableString(filter));
+        System.out.println(new String(HBaseFilterUtils.toParseableByteArray(filter)));
+        Assert.assertArrayEquals("PrefixFilter('prefix')".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testSkipFilter() {
+    public void testSkipFilter() throws IOException {
         RowFilter rowFilter = new RowFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(
             "testSkipFilter".getBytes()));
         SkipFilter filter = new SkipFilter(rowFilter);
-        Assert.assertEquals("(SKIP RowFilter(=,'binary:testSkipFilter'))",
-            HBaseFilterUtils.toParseableString(filter));
+        Assert.assertArrayEquals("(SKIP RowFilter(=,'binary:testSkipFilter'))".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testWhileFilter() {
+    public void testWhileFilter() throws IOException {
         QualifierFilter qualifierFilter = new QualifierFilter(CompareFilter.CompareOp.GREATER,
             new BinaryPrefixComparator("whileMatchFilter".getBytes()));
         WhileMatchFilter filter = new WhileMatchFilter(qualifierFilter);
-        Assert.assertEquals("(WHILE QualifierFilter(>,'binaryprefix:whileMatchFilter'))",
-            HBaseFilterUtils.toParseableString(filter));
+        Assert.assertArrayEquals("(WHILE QualifierFilter(>,'binaryprefix:whileMatchFilter'))".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
-    public void testFilterList() {
+    public void testFilterList() throws IOException {
         RowFilter rowFilter = new RowFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(
             "testSkipFilter".getBytes()));
         QualifierFilter qualifierFilter = new QualifierFilter(CompareFilter.CompareOp.GREATER,
@@ -177,21 +179,21 @@ public class HBaseFilterUtilsTest {
         filterList.addFilter(skipFilter);
         filterList.addFilter(columnPaginationFilter);
 
-        Assert
-            .assertEquals(
-                "(RowFilter(=,'binary:testSkipFilter') "
-                        + "AND QualifierFilter(>,'binaryprefix:whileMatchFilter') AND (SKIP PageFilter(128)) AND ColumnPaginationFilter(2,2))",
-                HBaseFilterUtils.toParseableString(filterList));
+
+        System.out.println(new String(HBaseFilterUtils.toParseableByteArray(filterList)));
+        Assert.assertArrayEquals(
+                ("(RowFilter(=,'binary:testSkipFilter') "
+                        + "AND QualifierFilter(>,'binaryprefix:whileMatchFilter') AND (SKIP PageFilter(128)) AND ColumnPaginationFilter(2,2))").getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filterList));
 
         filterList = new FilterList(FilterList.Operator.MUST_PASS_ONE);
         filterList.addFilter(rowFilter);
         filterList.addFilter(qualifierFilter);
         filterList.addFilter(columnPaginationFilter);
 
-        Assert
-            .assertEquals(
-                "(RowFilter(=,'binary:testSkipFilter') "
-                        + "OR QualifierFilter(>,'binaryprefix:whileMatchFilter') OR ColumnPaginationFilter(2,2))",
-                HBaseFilterUtils.toParseableString(filterList));
+        Assert.assertArrayEquals(
+                    ("(RowFilter(=,'binary:testSkipFilter') "
+                        + "OR QualifierFilter(>,'binaryprefix:whileMatchFilter') OR ColumnPaginationFilter(2,2))").getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filterList));
     }
 }

--- a/src/test/java/unit_test_db.sql
+++ b/src/test/java/unit_test_db.sql
@@ -160,5 +160,5 @@ CREATE TABLE `test_t$family'1` (
     `T` bigint(20) NOT NULL,
     `V` varbinary(1024) DEFAULT NULL,
     PRIMARY KEY (`K`, `Q`, `T`)
-) TABLEGROUP = test;
+) TABLEGROUP = test_t;
 

--- a/src/test/java/unit_test_db.sql
+++ b/src/test/java/unit_test_db.sql
@@ -145,3 +145,20 @@ CREATE TABLE `test_t$family_with_local_index` (
     key `idx1`(T) local,
     PRIMARY KEY (`K`, `Q`, `T`)
 );
+
+CREATE TABLE `test$family'1` (
+    `K` varbinary(1024) NOT NULL,
+    `Q` varbinary(256) NOT NULL,
+    `T` bigint(20) NOT NULL,
+    `V` varbinary(1024) DEFAULT NULL,
+    PRIMARY KEY (`K`, `Q`, `T`)
+) TABLEGROUP = test;
+
+CREATE TABLE `test_t$family'1` (
+    `K` varbinary(1024) NOT NULL,
+    `Q` varbinary(256) NOT NULL,
+    `T` bigint(20) NOT NULL,
+    `V` varbinary(1024) DEFAULT NULL,
+    PRIMARY KEY (`K`, `Q`, `T`)
+) TABLEGROUP = test;
+


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->


## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix checkAndMutate and get/Scan with filter return -5006 when include special character


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
1. escape special character for filter string to avoid parse error in server
2. use byte[] instead of String to pass filter String, because when convert byte[] to String and back, the byte maybe changed
