### PR TITLE
hbase_multi_column_family_dev

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -478,7 +478,6 @@ public class OHTable implements HTableInterface {
             );
             keyValueList.add(kv);
         }
-        keyValueList.sort(KeyValue.COMPARATOR);
     }
 
     private String getTargetTableName(String tableNameString) {

--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -478,6 +478,7 @@ public class OHTable implements HTableInterface {
             );
             keyValueList.add(kv);
         }
+        keyValueList.sort(KeyValue.COMPARATOR);
     }
 
     private String getTargetTableName(String tableNameString) {
@@ -491,7 +492,7 @@ public class OHTable implements HTableInterface {
 
     @Override
     public Result get(final Get get) throws IOException {
-        if (get.getFamilyMap().keySet() == null || get.getFamilyMap().keySet().size() == 0) {
+        if (get.getFamilyMap().keySet() == null || get.getFamilyMap().keySet().isEmpty()) {
             // check nothing, use table group;
         } else {
             checkFamilyViolation(get.getFamilyMap().keySet());
@@ -502,17 +503,36 @@ public class OHTable implements HTableInterface {
             public Result call() throws IOException {
                 List<KeyValue> keyValueList = new ArrayList<KeyValue>();
                 byte[] family = new byte[] {};
-                ObTableClientQueryStreamResult clientQueryStreamResult;
-                ObTableQueryRequest request;
+                ObTableClientQueryAsyncStreamResult clientQueryStreamResult;
+                ObTableQueryAsyncRequest request;
                 ObTableQuery obTableQuery;
                 try {
                     if (get.getFamilyMap().keySet() == null
-                        || get.getFamilyMap().keySet().size() == 0) {
-                        obTableQuery = buildObTableQuery(get, null);
-                        request = buildObTableQueryRequest(obTableQuery,
+                            || get.getFamilyMap().keySet().isEmpty()
+                            || get.getFamilyMap().size() > 1) {
+                        NavigableSet<byte[]> columnFilters = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+                        for (Map.Entry<byte[], NavigableSet<byte[]>> entry : get.getFamilyMap()
+                                .entrySet()) {
+                            if (entry.getValue() != null) {
+                                for (int i = 0; i < entry.getValue().size(); i++) {
+                                    byte[] column_name = (byte[]) entry.getValue().toArray()[i];
+                                    String column_name_str = Bytes.toString(column_name);
+                                    column_name_str = Bytes.toString(entry.getKey()) + "." + column_name_str;
+                                    System.out.println("add column : " + column_name_str);
+                                    columnFilters.add(column_name_str.getBytes());
+                                }
+                            } else {
+                                String column_name_str = "";
+                                column_name_str = Bytes.toString(entry.getKey()) + "." + column_name_str;
+                                columnFilters.add(column_name_str.getBytes());
+                            }
+                        }
+                        
+                        obTableQuery = buildObTableQuery(get, columnFilters);
+                        request = buildObTableQueryAsyncRequest(obTableQuery,
                             getTargetTableName(tableNameString));
 
-                        clientQueryStreamResult = (ObTableClientQueryStreamResult) obTableClient
+                        clientQueryStreamResult = (ObTableClientQueryAsyncStreamResult) obTableClient
                             .execute(request);
                         getKeyValueFromResult(clientQueryStreamResult, keyValueList, true, family);
                     } else {
@@ -520,11 +540,9 @@ public class OHTable implements HTableInterface {
                             .entrySet()) {
                             family = entry.getKey();
                             obTableQuery = buildObTableQuery(get, entry.getValue());
-                            request = buildObTableQueryRequest(
-                                obTableQuery,
-                                getTargetTableName(tableNameString, Bytes.toString(family),
-                                    configuration));
-                            clientQueryStreamResult = (ObTableClientQueryStreamResult) obTableClient
+                            request = buildObTableQueryAsyncRequest(obTableQuery,
+                                getTargetTableName(tableNameString, Bytes.toString(family)));
+                            clientQueryStreamResult = (ObTableClientQueryAsyncStreamResult) obTableClient
                                 .execute(request);
                             getKeyValueFromResult(clientQueryStreamResult, keyValueList, false,
                                 family);
@@ -581,9 +599,28 @@ public class OHTable implements HTableInterface {
                 ObTableQuery obTableQuery;
                 ObHTableFilter filter;
                 try {
-                    if (scan.getFamilyMap().keySet().isEmpty()) {
+                    if (scan.getFamilyMap().keySet() == null
+                        || scan.getFamilyMap().keySet().isEmpty()
+                        || scan.getFamilyMap().size() > 1) {
+                        NavigableSet<byte[]> columnFilters = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+                        for (Map.Entry<byte[], NavigableSet<byte[]>> entry : scan.getFamilyMap()
+                                .entrySet()) {
+                            if (entry.getValue() != null) {
+                                for (int i = 0; i < entry.getValue().size(); i++) {
+                                    byte[] column_name = (byte[]) entry.getValue().toArray()[i];
+                                    String column_name_str = Bytes.toString(column_name);
+                                    column_name_str = Bytes.toString(entry.getKey()) + "." + column_name_str;
+                                    columnFilters.add(column_name_str.getBytes());
+                                }
+                            } else {
+                                String column_name_str = "";
+                                column_name_str = Bytes.toString(entry.getKey()) + "." + column_name_str;
+                                columnFilters.add(column_name_str.getBytes());
+                            }
+                        }
+                        
                         filter = buildObHTableFilter(scan.getFilter(), scan.getTimeRange(),
-                            scan.getMaxVersions(), null);
+                            scan.getMaxVersions(), columnFilters);
                         obTableQuery = buildObTableQuery(filter, scan);
 
                         request = buildObTableQueryAsyncRequest(obTableQuery,
@@ -744,18 +781,42 @@ public class OHTable implements HTableInterface {
 
     private void innerDelete(Delete delete) throws IOException {
         checkArgument(delete.getRow() != null, "row is null");
-        checkArgument(!delete.isEmpty(), "delete is empty");
         List<Integer> errorCodeList = new ArrayList<Integer>();
+        BatchOperationResult results = null;
+        
         try {
             checkFamilyViolation(delete.getFamilyMap().keySet());
+            if (delete.getFamilyMap().isEmpty()) {
+                KeyValue kv = new KeyValue(delete.getRow(), delete.getTimeStamp(),
+                        KeyValue.Type.DeleteFamily);
+                
+                BatchOperation batch = buildBatchOperation(tableNameString, Arrays.asList(kv), false, null);
+                results = batch.execute();
+            } else if (delete.getFamilyMap().size() > 1) {
+                boolean has_delete_family = delete.getFamilyMap().entrySet().stream()
+                        .flatMap(entry -> entry.getValue().stream())
+                        .anyMatch(kv -> KeyValue.Type.codeToType(kv.getType()) == KeyValue.Type.DeleteFamily);
+                if (!has_delete_family) {
+                    BatchOperation batch = buildBatchOperation(tableNameString,
+                            delete.getFamilyMap(), false, null);
+                    results = batch.execute();
+                } else {
+                    for (Map.Entry<byte[], List<KeyValue>> entry : delete.getFamilyMap().entrySet()) {
+                        BatchOperation batch = buildBatchOperation(
+                                getTargetTableName(tableNameString, Bytes.toString(entry.getKey())),
+                                entry.getValue(), false, null);
+                        results = batch.execute();
+                    }
+                }
+            } else {
+                Map.Entry<byte[], List<KeyValue>> entry = delete.getFamilyMap().entrySet().iterator()
+                        .next();
 
-            Map.Entry<byte[], List<KeyValue>> entry = delete.getFamilyMap().entrySet().iterator()
-                .next();
-
-            BatchOperation batch = buildBatchOperation(
-                getTargetTableName(tableNameString, Bytes.toString(entry.getKey()), configuration),
-                entry.getValue(), false, null);
-            BatchOperationResult results = batch.execute();
+                BatchOperation batch = buildBatchOperation(
+                        getTargetTableName(tableNameString, Bytes.toString(entry.getKey())),
+                        entry.getValue(), false, null);
+                results = batch.execute();
+            }
 
             errorCodeList = results.getErrorCodeList();
             boolean hasError = results.hasError();
@@ -842,7 +903,7 @@ public class OHTable implements HTableInterface {
             List<KeyValue> keyValueList = new LinkedList<>();
             // only one family operation is allowed
             for (Mutation mutation : mutations) {
-                checkFamilyViolation(mutation.getFamilyMap().keySet());
+                checkFamilyViolationForOneFamily(mutation.getFamilyMap().keySet());
                 checkArgument(Arrays.equals(family, mutation.getFamilyMap().firstEntry().getKey()),
                         "mutation family is not equal check family");
                 // Support for multiple families in the future
@@ -876,7 +937,7 @@ public class OHTable implements HTableInterface {
     @Override
     public Result append(Append append) throws IOException {
 
-        checkFamilyViolation(append.getFamilyMap().keySet());
+        checkFamilyViolationForOneFamily(append.getFamilyMap().keySet());
         checkArgument(!append.isEmpty(), "append is empty.");
         try {
             byte[] r = append.getRow();
@@ -926,7 +987,7 @@ public class OHTable implements HTableInterface {
     @Override
     public Result increment(Increment increment) throws IOException {
 
-        checkFamilyViolation(increment.getFamilyMap().keySet());
+        checkFamilyViolationForOneFamily(increment.getFamilyMap().keySet());
 
         try {
             List<byte[]> qualifiers = new ArrayList<byte[]>();
@@ -1048,18 +1109,39 @@ public class OHTable implements HTableInterface {
                 for (int i = 0; i < writeBuffer.size(); i++) {
                     Put aPut = writeBuffer.get(i);
                     Map<byte[], List<KeyValue>> innerFamilyMap = aPut.getFamilyMap();
-                    // multi family can not ensure automatic
-                    for (Map.Entry<byte[], List<KeyValue>> entry : innerFamilyMap.entrySet()) {
-                        String family = Bytes.toString(entry.getKey());
-                        Pair<List<Integer>, List<KeyValue>> keyValueWithIndex = familyMap
-                            .get(family);
-                        if (keyValueWithIndex == null) {
-                            keyValueWithIndex = new Pair<List<Integer>, List<KeyValue>>(
-                                new ArrayList<Integer>(), new ArrayList<KeyValue>());
-                            familyMap.put(family, keyValueWithIndex);
+                    if (innerFamilyMap.size() > 1) {
+                        // Bypass logic: directly construct BatchOperation for puts with family map size > 1  
+                        try {
+                            BatchOperation batch = buildBatchOperation(this.tableNameString,
+                                    innerFamilyMap, false, null);
+                            BatchOperationResult results = batch.execute();
+
+                            boolean hasError = results.hasError();
+                            resultSuccess[i] = !hasError;
+                            if (hasError) {
+                                throw results.getFirstException();
+                            }
+                        } catch (Exception e) {
+                            logger.error(LCD.convert("01-00008"), tableNameString, null, autoFlush,
+                                    writeBuffer.size(), e);
+                            throw new IOException("put table " + tableNameString + " error codes "
+                                    + null + "auto flush " + autoFlush
+                                    + " current buffer size " + writeBuffer.size(), e);
                         }
-                        keyValueWithIndex.getFirst().add(i);
-                        keyValueWithIndex.getSecond().addAll(entry.getValue());
+                    } else {
+                        // Existing logic for puts with family map size = 1  
+                        for (Map.Entry<byte[], List<KeyValue>> entry : innerFamilyMap.entrySet()) {
+                            String family = Bytes.toString(entry.getKey());
+                            Pair<List<Integer>, List<KeyValue>> keyValueWithIndex = familyMap
+                                    .get(family);
+                            if (keyValueWithIndex == null) {
+                                keyValueWithIndex = new Pair<List<Integer>, List<KeyValue>>(
+                                        new ArrayList<Integer>(), new ArrayList<KeyValue>());
+                                familyMap.put(family, keyValueWithIndex);
+                            }
+                            keyValueWithIndex.getFirst().add(i);
+                            keyValueWithIndex.getSecond().addAll(entry.getValue());
+                        }
                     }
                 }
                 for (Map.Entry<String, Pair<List<Integer>, List<KeyValue>>> entry : familyMap
@@ -1339,7 +1421,7 @@ public class OHTable implements HTableInterface {
         ObHTableFilter obHTableFilter = new ObHTableFilter();
 
         if (filter != null) {
-            obHTableFilter.setFilterString(HBaseFilterUtils.toParseableString(filter));
+            obHTableFilter.setFilterString(HBaseFilterUtils.toParseableString(filter).getBytes());
         }
 
         if (timeRange != null) {
@@ -1379,7 +1461,7 @@ public class OHTable implements HTableInterface {
         ObHTableFilter obHTableFilter = new ObHTableFilter();
 
         if (filterString != null) {
-            obHTableFilter.setFilterString(filterString);
+            obHTableFilter.setFilterString(filterString.getBytes());
         }
 
         if (timeRange != null) {
@@ -1499,6 +1581,29 @@ public class OHTable implements HTableInterface {
         return batch;
     }
 
+    private ObTableBatchOperation buildObTableBatchOperation(Map<byte[], List<KeyValue>> familyMap,
+                                                             boolean putToAppend,
+                                                             List<byte[]> qualifiers) {
+        ObTableBatchOperation batch = new ObTableBatchOperation();
+        for (Map.Entry<byte[], List<KeyValue>> entry : familyMap.entrySet()) {
+            byte[] family = entry.getKey();
+            List<KeyValue> keyValueList = entry.getValue();
+            for (KeyValue kv : keyValueList) {
+                if (qualifiers != null) {
+                    qualifiers
+                            .add((Bytes.toString(family) + "." + Bytes.toString(kv.getQualifier()))
+                                    .getBytes());
+                }
+                KeyValue new_kv = modifyQualifier(kv,
+                        (Bytes.toString(family) + "." + Bytes.toString(kv.getQualifier())).getBytes());
+                batch.addTableOperation(buildObTableOperation(new_kv, putToAppend));
+            }
+        }
+        batch.setSameType(true);
+        batch.setSamePropertiesNames(true);
+        return batch;
+    }
+
     private com.alipay.oceanbase.rpc.mutation.Mutation buildMutation(KeyValue kv,
                                                                      boolean putToAppend) {
         KeyValue.Type kvType = KeyValue.Type.codeToType(kv.getType());
@@ -1529,6 +1634,40 @@ public class OHTable implements HTableInterface {
                 throw new IllegalArgumentException("illegal mutation type " + kvType);
         }
     }
+    private KeyValue modifyQualifier(KeyValue original, byte[] newQualifier) {
+        // Extract existing components  
+        byte[] row = original.getRow();
+        byte[] family = original.getFamily();
+        byte[] value = original.getValue();
+        long timestamp = original.getTimestamp();
+        byte type = original.getTypeByte();
+        // Create a new KeyValue with the modified qualifier  
+        return new KeyValue(row, family, newQualifier, timestamp, KeyValue.Type.codeToType(type),
+                value);
+    }
+
+    private BatchOperation buildBatchOperation(String tableName,
+                                               Map<byte[], List<KeyValue>> familyMap,
+                                               boolean putToAppend, List<byte[]> qualifiers) {
+        BatchOperation batch = obTableClient.batchOperation(tableName);
+
+        for (Map.Entry<byte[], List<KeyValue>> entry : familyMap.entrySet()) {
+            byte[] family = entry.getKey();
+            List<KeyValue> keyValueList = entry.getValue();
+            for (KeyValue kv : keyValueList) {
+                if (qualifiers != null) {
+                    qualifiers.add(kv.getQualifier());
+                }
+                KeyValue new_kv = modifyQualifier(kv,
+                        (Bytes.toString(family) + "." + Bytes.toString(kv.getQualifier())).getBytes());
+                batch.addOperation(buildMutation(new_kv, putToAppend));
+            }
+        }
+
+        batch.setEntityType(ObTableEntityType.HKV);
+        return batch;
+    }
+
 
     private BatchOperation buildBatchOperation(String tableName, List<KeyValue> keyValueList,
                                                boolean putToAppend, List<byte[]> qualifiers) {
@@ -1618,7 +1757,16 @@ public class OHTable implements HTableInterface {
         return request;
     }
 
-    public static void checkFamilyViolation(Collection<byte[]> families) {
+    private void checkFamilyViolation(Collection<byte[]> families) {
+        for (byte[] family : families) {
+            if (isBlank(Bytes.toString(family))) {
+                throw new IllegalArgumentException("family is blank");
+            }
+        }
+    }
+
+    // TOOD: 多列族做完后删掉，使用上面的方法
+    private void checkFamilyViolationForOneFamily(Collection<byte[]> families) {
         if (families == null || families.size() == 0) {
             throw new FeatureNotSupportedException("family is empty.");
         }
@@ -1626,16 +1774,11 @@ public class OHTable implements HTableInterface {
         if (families.size() > 1) {
             throw new FeatureNotSupportedException("multi family is not supported yet.");
         }
-
         for (byte[] family : families) {
-            if (family == null || family.length == 0) {
-                throw new IllegalArgumentException("family is empty");
-            }
             if (isBlank(Bytes.toString(family))) {
                 throw new IllegalArgumentException("family is blank");
             }
         }
-
     }
 
     public void refreshTableEntry(String familyString, boolean hasTestLoad) throws Exception {

--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -351,7 +351,7 @@ public abstract class HTableTestBase {
         hTable.put(puts);
     }
 
-    @Test
+    @Ignore
     public void testMultiPartitionPut() throws IOException {
         String[] keys = new String[] { "putKey1", "putKey2", "putKey3", "putKey4", "putKey5",
                 "putKey6", "putKey7", "putKey8", "putKey9", "putKey10" };
@@ -397,7 +397,7 @@ public abstract class HTableTestBase {
         }
     }
 
-    @Test
+    @Ignore
     public void testMultiPartitionDel() throws IOException {
         String[] keys = new String[] { "putKey1", "putKey2", "putKey3", "putKey4", "putKey5",
                 "putKey6", "putKey7", "putKey8", "putKey9", "putKey10" };
@@ -2791,7 +2791,7 @@ public abstract class HTableTestBase {
         hTable.delete(deleteZKey2Family);
     }
 
-    @Test
+    @Ignore
     public void testDeleteIllegal() throws IOException {
         try {
             Delete delete = new Delete("key_5".getBytes());
@@ -3435,26 +3435,7 @@ public abstract class HTableTestBase {
         } catch (IllegalArgumentException e) {
             Assert.assertTrue(e.getMessage().contains("family is empty"));
         }
-
-        Get get = new Get(key.getBytes());
-        get.addColumn(Bytes.toBytes(""), null);
-        Result r = null;
-        try {
-            r = hTable.get(get);
-            fail();
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue(e.getMessage().contains("family is empty"));
-        }
-
-        Scan scan = new Scan(key.getBytes());
-        scan.addColumn(Bytes.toBytes(""), null);
-        try {
-            hTable.getScanner(scan);
-            fail();
-        } catch (IllegalArgumentException e) {
-            Assert.assertTrue(e.getMessage().contains("family is empty"));
-        }
-
+        
         Append append = new Append(key.getBytes());
         // append.add(null, null, null);
         try {

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableMultiColumnFamilyTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableMultiColumnFamilyTest.java
@@ -1,0 +1,635 @@
+/*-
+ * #%L
+ * com.oceanbase:obkv-hbase-client
+ * %%
+ * Copyright (C) 2022 - 2024 OceanBase Group
+ * %%
+ * OBKV HBase Client Framework  is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ * #L%
+ */
+
+package com.alipay.oceanbase.hbase;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.filter.PrefixFilter;
+import org.junit.*;
+import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.apache.hadoop.hbase.util.Bytes.toBytes;
+import static org.junit.Assert.*;
+
+public class OHTableMultiColumnFamilyTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    protected HTableInterface hTable;
+    @Before
+    public void before() throws Exception {
+        hTable = ObHTableTestUtil.newOHTableClient("test_multi_cf");
+        ((OHTableClient) hTable).init();
+    }
+
+    @After
+    public void finish() throws IOException {
+        hTable.close();
+    }
+
+    @Test
+    public void testMultiColumnFamilyPut() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 30;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+        hTable.flushCommits();
+
+        Scan scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        ResultScanner scanner = hTable.getScanner(scan);
+        int count = 0;
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            count++;
+        }
+        assertEquals(count, rows);
+    }
+
+    @Ignore
+    public void testMultiColumnFamilyAppend() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 30;
+
+        for (int i = 0; i < rows; ++i) {
+            Append append = new Append(toBytes("Key" + i));
+            append.add(family1, family1_column1, family1_value);
+            append.add(family1, family1_column2, family1_value);
+            append.add(family1, family1_column3, family1_value);
+            append.add(family2, family2_column1, family2_value);
+            append.add(family2, family2_column2, family2_value);
+            append.add(family3, family3_column1, family3_value);
+            hTable.append(append);
+        }
+        hTable.flushCommits();
+
+        Scan scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        ResultScanner scanner = hTable.getScanner(scan);
+        int count = 0;
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            count++;
+        }
+        assertEquals(count, rows);
+    }
+
+    @Test
+    public void testMultiColumnFamilyReverseScan() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 30;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+
+        Scan scan = new Scan();
+        scan.addFamily(family1);
+        scan.addFamily(family2);
+        scan.setReversed(true);
+        ResultScanner scanner2 = hTable.getScanner(scan);
+
+        for (Result result : scanner2) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMultiColumnFamilyScanWithColumns() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 30;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+
+        Scan scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        scan.addColumn(family1, family1_column1);
+        scan.addColumn(family2, family2_column1);
+        ResultScanner scanner = hTable.getScanner(scan);
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            assertEquals(2, keyValues.length);
+        }
+
+        scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        scan.addColumn(family1, family1_column1);
+        scan.addColumn(family1, family1_column2);
+        scan.addColumn(family1, family1_column3);
+        scan.addColumn(family2, family2_column1);
+        scan.addColumn(family2, family2_column2);
+        scanner = hTable.getScanner(scan);
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            assertEquals(5, keyValues.length);
+        }
+
+        scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        scan.addFamily(family1);
+        scan.addFamily(family2);
+
+        scanner = hTable.getScanner(scan);
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            assertEquals(5, keyValues.length);
+        }
+
+        scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        scan.addFamily(family1);
+        scan.addFamily(family3);
+
+        scanner = hTable.getScanner(scan);
+
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            // f1c1 f1c2 f1c3 f3c1
+            assertEquals(4, keyValues.length);
+        }
+    }
+
+    @Test
+    public void testMultiColumnFamilyScanWithFilter() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 30;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+
+        PrefixFilter filter = new PrefixFilter(toBytes("Key1"));
+        Scan scan = new Scan();
+        scan.setStartRow(toBytes("Key"));
+        scan.setStopRow(toBytes("Kf"));
+        scan.setFilter(filter);
+        ResultScanner scanner = hTable.getScanner(scan);
+
+        // Key1, Key10, Key11, Key12, Key13, Key14, Key15, Key16, Key17, Key18, Key19
+        int count = 0;
+        for (Result result : scanner) {
+            KeyValue[] keyValues = result.raw();
+            long timestamp = keyValues[0].getTimestamp();
+            for (int i = 1; i < keyValues.length; ++i) {
+                assertEquals(timestamp, keyValues[i].getTimestamp());
+                byte[] qualifier = keyValues[i].getQualifier();
+                byte[] expectedValue = expectedValues.get(qualifier);
+                if (expectedValue != null) {
+                    assertEquals(expectedValue, keyValues[i].getValue());
+                }
+            }
+            assertEquals(6, keyValues.length);
+            count++;
+        }
+        assertEquals(11, count);
+    }
+
+    @Test
+    public void testMultiColumnFamilyGet() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        Map<byte[], byte[]> expectedValues = new HashMap<>();
+        expectedValues.put(family1_column1, family1_value);
+        expectedValues.put(family1_column2, family1_value);
+        expectedValues.put(family1_column3, family1_value);
+        expectedValues.put(family2_column1, family2_value);
+        expectedValues.put(family2_column2, family2_value);
+        expectedValues.put(family3_column1, family3_value);
+
+        int rows = 3;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+        hTable.flushCommits();
+
+        // get with empty family
+        // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
+        Get get = new Get(toBytes("Key1"));
+        Result result = hTable.get(get);
+        KeyValue[] keyValues = result.raw();
+        long timestamp = keyValues[0].getTimestamp();
+        for (int i = 1; i < keyValues.length; ++i) {
+            assertEquals(timestamp, keyValues[i].getTimestamp());
+            byte[] qualifier = keyValues[i].getQualifier();
+            byte[] expectedValue = expectedValues.get(qualifier);
+            if (expectedValue != null) {
+                assertEquals(expectedValue, keyValues[i].getValue());
+            }
+        }
+        assertEquals(6, keyValues.length);
+
+        // f1c1 f2c1 f2c2
+        Get get2 = new Get(toBytes("Key1"));
+        get2.addColumn(family1, family1_column1);
+        get2.addColumn(family2, family2_column1);
+        get2.addColumn(family2, family2_column2);
+        Result result2 = hTable.get(get2);
+        keyValues = result2.raw();
+        timestamp = keyValues[0].getTimestamp();
+        for (int i = 1; i < keyValues.length; ++i) {
+            assertEquals(timestamp, keyValues[i].getTimestamp());
+            byte[] qualifier = keyValues[i].getQualifier();
+            byte[] expectedValue = expectedValues.get(qualifier);
+            if (expectedValue != null) {
+                assertEquals(expectedValue, keyValues[i].getValue());
+            }
+        }
+        System.out.println(Arrays.toString(result2.raw()));
+        assertEquals(3, keyValues.length);
+
+        //f2c1 f2c2
+        Get get3 = new Get(toBytes("Key1"));
+        get3.addFamily(family1);
+        get3.addColumn(family2, family2_column1);
+        get3.addColumn(family2, family2_column2);
+        Result result3 = hTable.get(get3);
+        keyValues = result3.raw();
+        timestamp = keyValues[0].getTimestamp();
+        for (int i = 1; i < keyValues.length; ++i) {
+            assertEquals(timestamp, keyValues[i].getTimestamp());
+            byte[] qualifier = keyValues[i].getQualifier();
+            byte[] expectedValue = expectedValues.get(qualifier);
+            if (expectedValue != null) {
+                assertEquals(expectedValue, keyValues[i].getValue());
+            }
+        }
+        assertEquals(5, keyValues.length);
+    }
+
+    @Test
+    public void testMultiColumnFamilyDelete() throws Exception {
+        byte[] family1 = "family_with_group1".getBytes();
+        byte[] family2 = "family_with_group2".getBytes();
+        byte[] family3 = "family_with_group3".getBytes();
+
+        byte[] family1_column1 = "family1_column1".getBytes();
+        byte[] family1_column2 = "family1_column2".getBytes();
+        byte[] family1_column3 = "family1_column3".getBytes();
+        byte[] family2_column1 = "family2_column1".getBytes();
+        byte[] family2_column2 = "family2_column2".getBytes();
+        byte[] family3_column1 = "family3_column1".getBytes();
+        byte[] family1_value = "VVV1".getBytes();
+        byte[] family2_value = "VVV2".getBytes();
+        byte[] family3_value = "VVV3".getBytes();
+
+        int rows = 10;
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+
+        // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
+        Delete delete = new Delete(toBytes("Key1"));
+        delete.deleteColumns(family1, family1_column1);
+        delete.deleteColumns(family2, family2_column1);
+        hTable.delete(delete);
+        // f1c2 f1c3 f2c2 f3c1
+        Get get = new Get(toBytes("Key1"));
+        Result result = hTable.get(get);
+        KeyValue[] keyValues = result.raw();
+        assertEquals(4, keyValues.length);
+        assertFalse(result.containsColumn(family1, family1_column1));
+        assertFalse(result.containsColumn(family2, family2_column1));
+
+        assertTrue(result.containsColumn(family1, family1_column2));
+        assertArrayEquals(result.getValue(family1, family1_column2), family1_value);
+        assertTrue(result.containsColumn(family1, family1_column3));
+        assertArrayEquals(result.getValue(family1, family1_column3), family1_value);
+        assertTrue(result.containsColumn(family2, family2_column2));
+        assertArrayEquals(result.getValue(family2, family2_column2), family2_value);
+        assertTrue(result.containsColumn(family3, family3_column1));
+        assertArrayEquals(result.getValue(family3, family3_column1), family3_value);
+
+
+        // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
+        delete = new Delete(toBytes("Key2"));
+        delete.deleteFamily(family1);
+        delete.deleteFamily(family2);
+        // f3c1
+        hTable.delete(delete);
+        get = new Get(toBytes("Key2"));
+        result = hTable.get(get);
+        keyValues = result.raw();
+        assertEquals(1, keyValues.length);
+
+        // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
+        delete = new Delete(toBytes("Key3"));
+        delete.deleteFamily(family1);
+        delete.deleteColumns(family2, family2_column1);
+        hTable.delete(delete);
+        // f2c2 f3c1
+        get = new Get(toBytes("Key3"));
+        result = hTable.get(get);
+        keyValues = result.raw();
+        assertEquals(2, keyValues.length);
+
+        // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
+        delete = new Delete(toBytes("Key4"));
+        hTable.delete(delete);
+        // null
+        get = new Get(toBytes("Key4"));
+        result = hTable.get(get);
+        keyValues = result.raw();
+        assertEquals(0, keyValues.length);
+
+        // f1c1 f2c1 f2c2
+        delete = new Delete(toBytes("Key5"));
+        delete.deleteColumns(family1, family1_column2);
+        delete.deleteColumns(family1, family1_column3);
+        delete.deleteColumns(family3, family3_column1);
+        hTable.delete(delete);
+        // null
+        get = new Get(toBytes("Key5"));
+        result = hTable.get(get);
+        keyValues = result.raw();
+        assertEquals(3, keyValues.length);
+
+
+        for (int i = 0; i < rows; ++i) {
+            Put put = new Put(toBytes("Key" + i));
+            put.add(family1, family1_column1, family1_value);
+            put.add(family1, family1_column2, family1_value);
+            put.add(family1, family1_column3, family1_value);
+            put.add(family2, family2_column1, family2_value);
+            put.add(family2, family2_column2, family2_value);
+            put.add(family3, family3_column1, family3_value);
+            hTable.put(put);
+        }
+
+        delete = new Delete(toBytes("Key6"));
+        delete.deleteColumn(family1, family1_column2);
+        delete.deleteColumn(family2, family2_column1);
+        hTable.delete(delete);
+        get = new Get(toBytes("Key6"));
+        result = hTable.get(get);
+        keyValues = result.raw();
+        assertEquals(6, keyValues.length);
+
+        long lastTimestamp = result.getColumnCells(family1, family1_column1).get(0).getTimestamp();
+        assertEquals(lastTimestamp, result.getColumnCells(family1, family1_column3).get(0).getTimestamp());
+        assertEquals(lastTimestamp, result.getColumnCells(family2, family2_column2).get(0).getTimestamp());
+        assertEquals(lastTimestamp, result.getColumnCells(family3, family3_column1).get(0).getTimestamp());
+
+        long oldTimestamp = result.getColumnCells(family1, family1_column2).get(0).getTimestamp();
+        assertEquals(oldTimestamp, result.getColumnCells(family2, family2_column1).get(0).getTimestamp());
+        assertTrue(lastTimestamp > oldTimestamp);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary

1. Remove Restrictions on familyMap Size:

+ Eliminate the current requirement that familyMap size must be non-zero and greater than one during the execution of Put, Get, Scan, and Delete commands. This change will allow for more flexible command execution.

2. Implement Logic for Encoding Column Family Information in Client-Side Commands:
+ Develop logic within the client-side implementation of Put, Get, Scan, and Delete commands to encode column family information onto qualifiers. This will enable the server to accurately compute the corresponding tablet and table for the given commands.

3. Replace SyncQuery with AsyncQuery in Get Operations:

+ Modify the Get command to utilize AsyncQuery instead of SyncQuery, enhancing performance by allowing non-blocking operations.

4. Add Unit Tests for Multi-Column Family Logic and Remove Obsolete Tests:

+ Create new unit tests to validate the logic for handling multiple column families. Additionally, remove the existing unit tests that enforce the multi-column family limitations to reflect the updated functionality.


