### PR TITLE
fix bug when get set isClosestRow true

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTableClient.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTableClient.java
@@ -18,7 +18,6 @@
 package com.alipay.oceanbase.hbase;
 
 import com.alipay.oceanbase.hbase.core.Lifecycle;
-import com.alipay.oceanbase.hbase.exception.FeatureNotSupportedException;
 import com.google.protobuf.Descriptors;
 import com.google.protobuf.Message;
 import com.google.protobuf.Service;

--- a/src/main/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtils.java
@@ -23,8 +23,6 @@ import org.apache.hadoop.hbase.util.Bytes;
 
 import java.lang.reflect.Field;
 
-import static org.apache.hadoop.hbase.util.Bytes.bytesToVint;
-
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
@@ -38,7 +36,8 @@ public class HBaseFilterUtils {
         return byteStream.toByteArray();
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, Filter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, Filter filter)
+                                                                                             throws IOException {
         if (filter == null) {
             throw new IllegalArgumentException("Filter is null");
         } else if (filter instanceof CompareFilter) {
@@ -97,7 +96,8 @@ public class HBaseFilterUtils {
         }
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, ByteArrayComparable comparator) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             ByteArrayComparable comparator) throws IOException {
         if (comparator == null) {
             throw new IllegalArgumentException("Comparator is null");
         }
@@ -120,7 +120,8 @@ public class HBaseFilterUtils {
     }
 
     // CompareFilter(=,'binary:123')
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, CompareFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, CompareFilter filter)
+                                                                                                    throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
         byteStream.write(toParseableByteArray(filter.getOperator()));
@@ -130,7 +131,8 @@ public class HBaseFilterUtils {
     }
 
     // SingleColumnValueFilter('cf1','col1',=,'binary:123',true,true)
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, SingleColumnValueFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             SingleColumnValueFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write("('".getBytes());
         writeBytesWithEscape(byteStream, filter.getFamily());
@@ -148,21 +150,25 @@ public class HBaseFilterUtils {
     }
 
     // PageFilter(100);
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, PageFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, PageFilter filter)
+                                                                                                 throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
         byteStream.write(Long.toString(filter.getPageSize()).getBytes());
         byteStream.write(')');
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, RandomRowFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             RandomRowFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
-        byteStream.write(Integer.toString(Bytes.toInt(Bytes.toBytes(filter.getChance()))).getBytes());
+        byteStream.write(Integer.toString(Bytes.toInt(Bytes.toBytes(filter.getChance())))
+            .getBytes());
         byteStream.write(')');
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, ColumnPaginationFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             ColumnPaginationFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
         byteStream.write(Long.toString(filter.getLimit()).getBytes());
@@ -174,17 +180,19 @@ public class HBaseFilterUtils {
         } else {
             byteStream.write(Long.toString(filter.getOffset()).getBytes());
         }
-        byteStream .write(')');
+        byteStream.write(')');
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, ColumnPrefixFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             ColumnPrefixFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write("('".getBytes());
         writeBytesWithEscape(byteStream, filter.getPrefix());
         byteStream.write("')".getBytes());
     }
 
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, FirstKeyOnlyFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             FirstKeyOnlyFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
         byteStream.write(')');
@@ -227,23 +235,26 @@ public class HBaseFilterUtils {
     }
 
     // ColumnCountGetFilter(100)
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, ColumnCountGetFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             ColumnCountGetFilter filter) throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write('(');
         byteStream.write(Long.toString(filter.getLimit()).getBytes());
-        byteStream .write(')');
+        byteStream.write(')');
     }
 
     // PrefixFilter('prefix');
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, PrefixFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, PrefixFilter filter)
+                                                                                                   throws IOException {
         byteStream.write(filter.getClass().getSimpleName().getBytes());
         byteStream.write("('".getBytes());
         writeBytesWithEscape(byteStream, filter.getPrefix());
-        byteStream .write("')".getBytes());
+        byteStream.write("')".getBytes());
     }
 
     // (SKIP filter)
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, SkipFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, SkipFilter filter)
+                                                                                                 throws IOException {
         byteStream.write('(');
         byteStream.write(ParseConstants.SKIP_ARRAY);
         byteStream.write(' ');
@@ -252,7 +263,8 @@ public class HBaseFilterUtils {
     }
 
     // (WHILE filter)
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, WhileMatchFilter filter) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream,
+                                             WhileMatchFilter filter) throws IOException {
         byteStream.write('(');
         byteStream.write(ParseConstants.WHILE_ARRAY);
         byteStream.write(' ');
@@ -263,13 +275,16 @@ public class HBaseFilterUtils {
     // (filter and filter ...) or (filter or filter ...)
     // when filter list is empty, "" is generated, and empty filter list member is removed
     // in result parseable byteArray
-    private static void toParseableByteArray(ByteArrayOutputStream byteStream, FilterList filterList) throws IOException {
+    private static void toParseableByteArray(ByteArrayOutputStream byteStream, FilterList filterList)
+                                                                                                     throws IOException {
         List<Filter> filters = filterList.getFilters();
         boolean isEmpty = true;
         ByteArrayOutputStream oneFilterBytes = new ByteArrayOutputStream();
         for (int i = 0; i < filters.size(); i++) {
             toParseableByteArray(oneFilterBytes, filters.get(i));
-            if (oneFilterBytes.size() == 0) { continue; }
+            if (oneFilterBytes.size() == 0) {
+                continue;
+            }
             if (isEmpty) {
                 byteStream.write('(');
                 isEmpty = false;
@@ -294,7 +309,8 @@ public class HBaseFilterUtils {
 
     // when write family/qualifier/value/row into hbase filter, need add escape for
     // special character to prevent parse error in server
-    public static void writeBytesWithEscape(ByteArrayOutputStream byteStream, byte[] bytes) throws IOException {
+    public static void writeBytesWithEscape(ByteArrayOutputStream byteStream, byte[] bytes)
+                                                                                           throws IOException {
         if (bytes == null) {
             return;
         }

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
@@ -18,44 +18,24 @@
 package com.alipay.oceanbase.hbase.util;
 
 import com.alipay.oceanbase.hbase.OHTable;
-import com.alipay.oceanbase.hbase.exception.FeatureNotSupportedException;
 import com.alipay.oceanbase.rpc.ObTableClient;
-import com.alipay.oceanbase.rpc.exception.ObTableEntryRefreshException;
-import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.*;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.slf4j.Logger;
-import sun.awt.image.ImageWatched;
 
-import javax.ws.rs.PUT;
 import java.io.IOException;
-import java.io.InterruptedIOException;
-import java.rmi.UnexpectedException;
 import java.util.*;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
-import static com.alipay.oceanbase.hbase.constants.OHConstants.*;
-import static com.alipay.oceanbase.hbase.constants.OHConstants.DEFAULT_HBASE_HTABLE_TEST_LOAD_SUFFIX;
-import static com.alipay.oceanbase.hbase.util.Preconditions.checkArgument;
-import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperation.getInstance;
-import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperationType.*;
-import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperationType.DEL;
 import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.LCD;
-import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.RUNTIME;
-import static org.apache.commons.lang.StringUtils.isBlank;
 
 @InterfaceAudience.Private
 public class OHBufferedMutatorImpl implements BufferedMutator {

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
@@ -19,11 +19,8 @@ package com.alipay.oceanbase.hbase.util;
 
 import com.alipay.oceanbase.rpc.ObTableClient;
 import com.alipay.oceanbase.rpc.constant.Constants;
-import com.alipay.oceanbase.rpc.property.Property;
 import com.google.common.base.Objects;
 import org.apache.hadoop.classification.InterfaceAudience;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.client.ConnectionConfiguration;
 
 import java.io.IOException;
 import java.util.Map;

--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -3436,7 +3436,7 @@ public abstract class HTableTestBase {
         } catch (IllegalArgumentException e) {
             Assert.assertTrue(e.getMessage().contains("family is empty"));
         }
-        
+
         Append append = new Append(key.getBytes());
         // append.add(null, null, null);
         try {
@@ -3796,8 +3796,8 @@ public abstract class HTableTestBase {
         // check delete column
         delete = new Delete(keyBytes);
         delete.deleteColumn(family.getBytes(), columnBytes);
-        boolean ret = hTable.checkAndDelete(keyBytes, family.getBytes(), columnBytes,
-                valueBytes, delete);
+        boolean ret = hTable.checkAndDelete(keyBytes, family.getBytes(), columnBytes, valueBytes,
+            delete);
         Assert.assertTrue(ret);
 
         // 2. test normal filter with special chracter
@@ -3805,26 +3805,27 @@ public abstract class HTableTestBase {
         put.add(family.getBytes(), columnBytes, valueBytes);
         hTable.put(put);
 
-
         Get get = new Get(keyBytes);
         get.addFamily(family.getBytes());
         // 2.1 test special row
-        RowFilter rowFilter = new RowFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(keyBytes));
+        RowFilter rowFilter = new RowFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(
+            keyBytes));
         get.setFilter(rowFilter);
         Result result = hTable.get(get);
         Assert.assertEquals(1, result.raw().length);
         Assert.assertArrayEquals(keyBytes, result.getRow());
 
         // 2.2 test special column
-        SingleColumnValueFilter singleColumnValueFilter = new SingleColumnValueFilter(family.getBytes(),
-                columnBytes, CompareFilter.CompareOp.EQUAL, valueBytes);
+        SingleColumnValueFilter singleColumnValueFilter = new SingleColumnValueFilter(
+            family.getBytes(), columnBytes, CompareFilter.CompareOp.EQUAL, valueBytes);
         get.setFilter(singleColumnValueFilter);
         result = hTable.get(get);
         Assert.assertEquals(1, result.raw().length);
         Assert.assertArrayEquals(keyBytes, result.getRow());
 
         // 2.3 test special value
-        ValueFilter valueFilter = new ValueFilter(CompareFilter.CompareOp.EQUAL, new BinaryComparator(valueBytes));
+        ValueFilter valueFilter = new ValueFilter(CompareFilter.CompareOp.EQUAL,
+            new BinaryComparator(valueBytes));
         get.setFilter(valueFilter);
         result = hTable.get(get);
         Assert.assertEquals(1, result.raw().length);

--- a/src/test/java/com/alipay/oceanbase/hbase/LoggerTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/LoggerTest.java
@@ -19,17 +19,12 @@ package com.alipay.oceanbase.hbase;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Append;
-import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.Increment;
-import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
-import org.apache.hadoop.hbase.io.TimeRange;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.api.support.membermodification.MemberModifier;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -40,9 +35,6 @@ import java.io.IOException;
 import static org.apache.hadoop.hbase.util.Bytes.toBytes;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.anyString;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(OHTable.class)

--- a/src/test/java/com/alipay/oceanbase/hbase/OHConnectionTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHConnectionTest.java
@@ -18,7 +18,6 @@
 package com.alipay.oceanbase.hbase;
 
 import com.alipay.oceanbase.hbase.exception.FeatureNotSupportedException;
-import com.alipay.oceanbase.hbase.util.OHBufferedMutatorImpl;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.TableName;

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 public class OHTableClientTest extends HTableTestBase {
     @Before

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTestLoadTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableClientTestLoadTest.java
@@ -18,7 +18,6 @@
 package com.alipay.oceanbase.hbase;
 
 import com.alipay.oceanbase.rpc.exception.ObTableNotExistException;
-import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
 import org.apache.hadoop.hbase.client.Delete;
 import org.junit.After;
 import org.junit.Assert;

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableMultiColumnFamilyTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableMultiColumnFamilyTest.java
@@ -33,9 +33,10 @@ import static org.junit.Assert.*;
 
 public class OHTableMultiColumnFamilyTest {
     @Rule
-    public ExpectedException expectedException = ExpectedException.none();
+    public ExpectedException  expectedException = ExpectedException.none();
 
     protected HTableInterface hTable;
+
     @Before
     public void before() throws Exception {
         hTable = ObHTableTestUtil.newOHTableClient("test_multi_cf");
@@ -281,7 +282,7 @@ public class OHTableMultiColumnFamilyTest {
             }
             assertEquals(2, keyValues.length);
         }
-
+        scanner.close();
         scan = new Scan();
         scan.setStartRow(toBytes("Key"));
         scan.setStopRow(toBytes("Kf"));
@@ -305,7 +306,7 @@ public class OHTableMultiColumnFamilyTest {
             }
             assertEquals(5, keyValues.length);
         }
-
+        scanner.close();
         scan = new Scan();
         scan.setStartRow(toBytes("Key"));
         scan.setStopRow(toBytes("Kf"));
@@ -327,7 +328,7 @@ public class OHTableMultiColumnFamilyTest {
             }
             assertEquals(5, keyValues.length);
         }
-
+        scanner.close();
         scan = new Scan();
         scan.setStartRow(toBytes("Key"));
         scan.setStopRow(toBytes("Kf"));
@@ -350,6 +351,7 @@ public class OHTableMultiColumnFamilyTest {
             // f1c1 f1c2 f1c3 f3c1
             assertEquals(4, keyValues.length);
         }
+        scanner.close();
     }
 
     @Test
@@ -558,7 +560,6 @@ public class OHTableMultiColumnFamilyTest {
         assertTrue(result.containsColumn(family3, family3_column1));
         assertArrayEquals(result.getValue(family3, family3_column1), family3_value);
 
-
         // f1c1 f1c2 f1c3 f2c1 f2c2 f3c1
         delete = new Delete(toBytes("Key2"));
         delete.deleteFamily(family1);
@@ -602,7 +603,6 @@ public class OHTableMultiColumnFamilyTest {
         keyValues = result.raw();
         assertEquals(3, keyValues.length);
 
-
         for (int i = 0; i < rows; ++i) {
             Put put = new Put(toBytes("Key" + i));
             put.add(family1, family1_column1, family1_value);
@@ -624,12 +624,16 @@ public class OHTableMultiColumnFamilyTest {
         assertEquals(6, keyValues.length);
 
         long lastTimestamp = result.getColumnCells(family1, family1_column1).get(0).getTimestamp();
-        assertEquals(lastTimestamp, result.getColumnCells(family1, family1_column3).get(0).getTimestamp());
-        assertEquals(lastTimestamp, result.getColumnCells(family2, family2_column2).get(0).getTimestamp());
-        assertEquals(lastTimestamp, result.getColumnCells(family3, family3_column1).get(0).getTimestamp());
+        assertEquals(lastTimestamp, result.getColumnCells(family1, family1_column3).get(0)
+            .getTimestamp());
+        assertEquals(lastTimestamp, result.getColumnCells(family2, family2_column2).get(0)
+            .getTimestamp());
+        assertEquals(lastTimestamp, result.getColumnCells(family3, family3_column1).get(0)
+            .getTimestamp());
 
         long oldTimestamp = result.getColumnCells(family1, family1_column2).get(0).getTimestamp();
-        assertEquals(oldTimestamp, result.getColumnCells(family2, family2_column1).get(0).getTimestamp());
+        assertEquals(oldTimestamp, result.getColumnCells(family2, family2_column1).get(0)
+            .getTimestamp());
         assertTrue(lastTimestamp > oldTimestamp);
     }
 }

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTablePoolLoadTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTablePoolLoadTest.java
@@ -18,7 +18,6 @@
 package com.alipay.oceanbase.hbase;
 
 import com.alipay.oceanbase.rpc.exception.ObTableNotExistException;
-import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.HTableInterface;

--- a/src/test/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtilsTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/filter/HBaseFilterUtilsTest.java
@@ -43,19 +43,23 @@ public class HBaseFilterUtilsTest {
             RowFilter filter = new RowFilter(ops[i], new BinaryComparator(
                 "testRowFilter".getBytes()));
             String expect = String.format("RowFilter(%s,'binary:testRowFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new BinaryPrefixComparator("testRowFilter".getBytes()));
             expect = String.format("RowFilter(%s,'binaryprefix:testRowFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new RegexStringComparator("testRowFilter"));
             expect = String.format("RowFilter(%s,'regexstring:testRowFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new RowFilter(ops[i], new SubstringComparator("testRowFilter"));
             expect = String.format("RowFilter(%s,'substring:testrowfilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
@@ -65,20 +69,24 @@ public class HBaseFilterUtilsTest {
             ValueFilter filter = new ValueFilter(ops[i], new BinaryComparator(
                 "testValueFilter".getBytes()));
             String expect = String.format("ValueFilter(%s,'binary:testValueFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new BinaryPrefixComparator(
                 "testValueFilter".getBytes()));
             expect = String.format("ValueFilter(%s,'binaryprefix:testValueFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new RegexStringComparator("testValueFilter"));
             expect = String.format("ValueFilter(%s,'regexstring:testValueFilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new ValueFilter(ops[i], new SubstringComparator("testValueFilter"));
             expect = String.format("ValueFilter(%s,'substring:testvaluefilter')", opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
@@ -89,23 +97,27 @@ public class HBaseFilterUtilsTest {
                 "testQualifierFilter".getBytes()));
             String expect = String.format("QualifierFilter(%s,'binary:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new BinaryPrefixComparator(
                 "testQualifierFilter".getBytes()));
             expect = String.format("QualifierFilter(%s,'binaryprefix:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new RegexStringComparator("testQualifierFilter"));
             expect = String.format("QualifierFilter(%s,'regexstring:testQualifierFilter')",
                 opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
 
             filter = new QualifierFilter(ops[i], new SubstringComparator("testQualifierFilter"));
             expect = String.format("QualifierFilter(%s,'substring:testqualifierfilter')",
                 opFlags[i]);
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
@@ -117,14 +129,16 @@ public class HBaseFilterUtilsTest {
                 opFlags[i]);
             SingleColumnValueFilter filter = new SingleColumnValueFilter("family".getBytes(),
                 "qualifier".getBytes(), ops[i], "value".getBytes());
-            Assert.assertArrayEquals(expect.getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+            Assert.assertArrayEquals(expect.getBytes(),
+                HBaseFilterUtils.toParseableByteArray(filter));
         }
     }
 
     @Test
     public void testPageFilter() throws IOException {
         PageFilter filter = new PageFilter(128);
-        Assert.assertArrayEquals("PageFilter(128)".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+        Assert.assertArrayEquals("PageFilter(128)".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
@@ -148,14 +162,16 @@ public class HBaseFilterUtilsTest {
     @Test
     public void testColumnCountGetFilter() throws IOException {
         ColumnCountGetFilter filter = new ColumnCountGetFilter(513);
-        Assert.assertArrayEquals("ColumnCountGetFilter(513)".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+        Assert.assertArrayEquals("ColumnCountGetFilter(513)".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
     public void testPrefixFilter() throws IOException {
         PrefixFilter filter = new PrefixFilter("prefix".getBytes());
         System.out.println(new String(HBaseFilterUtils.toParseableByteArray(filter)));
-        Assert.assertArrayEquals("PrefixFilter('prefix')".getBytes(), HBaseFilterUtils.toParseableByteArray(filter));
+        Assert.assertArrayEquals("PrefixFilter('prefix')".getBytes(),
+            HBaseFilterUtils.toParseableByteArray(filter));
     }
 
     @Test
@@ -172,7 +188,8 @@ public class HBaseFilterUtilsTest {
         QualifierFilter qualifierFilter = new QualifierFilter(CompareFilter.CompareOp.GREATER,
             new BinaryPrefixComparator("whileMatchFilter".getBytes()));
         WhileMatchFilter filter = new WhileMatchFilter(qualifierFilter);
-        Assert.assertArrayEquals("(WHILE QualifierFilter(>,'binaryprefix:whileMatchFilter'))".getBytes(),
+        Assert.assertArrayEquals(
+            "(WHILE QualifierFilter(>,'binaryprefix:whileMatchFilter'))".getBytes(),
             HBaseFilterUtils.toParseableByteArray(filter));
     }
 
@@ -191,21 +208,22 @@ public class HBaseFilterUtilsTest {
         filterList.addFilter(skipFilter);
         filterList.addFilter(columnPaginationFilter);
 
-
         System.out.println(new String(HBaseFilterUtils.toParseableByteArray(filterList)));
-        Assert.assertArrayEquals(
+        Assert
+            .assertArrayEquals(
                 ("(RowFilter(=,'binary:testSkipFilter') "
-                        + "AND QualifierFilter(>,'binaryprefix:whileMatchFilter') AND (SKIP PageFilter(128)) AND ColumnPaginationFilter(2,2))").getBytes(),
-                HBaseFilterUtils.toParseableByteArray(filterList));
+                 + "AND QualifierFilter(>,'binaryprefix:whileMatchFilter') AND (SKIP PageFilter(128)) AND ColumnPaginationFilter(2,2))")
+                    .getBytes(), HBaseFilterUtils.toParseableByteArray(filterList));
 
         filterList = new FilterList(FilterList.Operator.MUST_PASS_ONE);
         filterList.addFilter(rowFilter);
         filterList.addFilter(qualifierFilter);
         filterList.addFilter(columnPaginationFilter);
 
-        Assert.assertArrayEquals(
-                    ("(RowFilter(=,'binary:testSkipFilter') "
-                        + "OR QualifierFilter(>,'binaryprefix:whileMatchFilter') OR ColumnPaginationFilter(2,2))").getBytes(),
-                HBaseFilterUtils.toParseableByteArray(filterList));
+        Assert
+            .assertArrayEquals(
+                ("(RowFilter(=,'binary:testSkipFilter') "
+                 + "OR QualifierFilter(>,'binaryprefix:whileMatchFilter') OR ColumnPaginationFilter(2,2))")
+                    .getBytes(), HBaseFilterUtils.toParseableByteArray(filterList));
     }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->
Fixed the issue where incorrect results were returned when setting closeRow in a get operation under key partitioning. Additionally, fixed the problem where the client threw an exception when setting checkExistOnly in a get operation.

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->
