### PR TITLE
[task] observer support substring index as partition key

### DIFF
--- a/src/test/java/com/alipay/oceanbase/hbase/OHVarPrefixPartitionTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHVarPrefixPartitionTest.java
@@ -1,0 +1,42 @@
+package com.alipay.oceanbase.hbase;
+
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+
+/*-
+ * #%L
+ * OBKV HBase Client Framework
+ * %%
+ * Copyright (C) 2022 OceanBase Group
+ * %%
+ * OBKV HBase Client Framework  is licensed under Mulan PSL v2.
+ * You can use this software according to the terms and conditions of the Mulan PSL v2.
+ * You may obtain a copy of Mulan PSL v2 at:
+ *          http://license.coscl.org.cn/MulanPSL2
+ * THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND,
+ * EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT,
+ * MERCHANTABILITY OR FIT FOR A PARTICULAR PURPOSE.
+ * See the Mulan PSL v2 for more details.
+ * #L%
+ */
+
+/// Only support odp mode for now.
+public class OHVarPrefixPartitionTest extends HTableTestBase {
+    @Before
+    public void before() throws Exception {
+        hTable = ObHTableTestUtil.newOHTableClient("test_var_prefix_partition");
+        ((OHTableClient) hTable).init();
+    }
+
+    @After
+    public void finish() throws IOException {
+        hTable.close();
+    }
+
+    @After
+    public void after() throws IOException {
+        hTable.close();
+    }
+}

--- a/src/test/java/unit_test_db.sql
+++ b/src/test/java/unit_test_db.sql
@@ -54,6 +54,15 @@ CREATE TABLE `test$partitionFamily1` (
     PRIMARY KEY (`K`, `Q`, `T`)
 ) partition by key(`K`) partitions 17;
 
+CREATE TABLE `test_var_prefix_partition$family1` (
+    `K` varbinary(1024) NOT NULL,
+    `Q` varbinary(256) NOT NULL,
+    `T` bigint(20) NOT NULL,
+    `V` varbinary(1024) DEFAULT NULL,
+    `K_PREFIX` varbinary(1024) generated always as (SUBSTRING_INDEX(`K`, '.', 1)),
+    PRIMARY KEY (`K`, `Q`, `T`)
+) partition by key(`K_PREFIX`) partitions 15;
+
 CREATE TABLEGROUP test SHARDING = 'ADAPTIVE';
 CREATE TABLE `test$family_group` (
       `K` varbinary(1024) NOT NULL,


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
 1. observer support substring index as partition key


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
add test case for  substring index as partition key