### PR TITLE
Correctly close OHTable to avoid database credentials reused

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -1457,6 +1457,12 @@ public class OHTable implements HTableInterface {
         if (cleanupPoolOnClose) {
             executePool.shutdown();
         }
+        ObTableClientManager.clear();
+        try {
+            obTableClient.close();
+        } catch (Exception e) {
+            throw new IOException("fail to close obTableClient", e);
+        }
     }
 
     @Override

--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -1458,11 +1458,6 @@ public class OHTable implements HTableInterface {
             executePool.shutdown();
         }
         ObTableClientManager.clear();
-        try {
-            obTableClient.close();
-        } catch (Exception e) {
-            throw new IOException("fail to close obTableClient", e);
-        }
     }
 
     @Override

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
@@ -133,8 +133,7 @@ public class ObTableClientManager {
             for (Map.Entry<ObTableClientKey, ObTableClient> pair : OB_TABLE_CLIENT_INSTANCE.entrySet()) {
                 pair.getValue().close();
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new IOException("fail to close tableClient" , e);
         }
         OB_TABLE_CLIENT_INSTANCE.clear();

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
@@ -128,7 +128,15 @@ public class ObTableClientManager {
         return OB_TABLE_CLIENT_INSTANCE.get(obTableClientKey);
     }
 
-    public static void clear() {
+    public static void clear() throws IOException {
+        try {
+            for (Map.Entry<ObTableClientKey, ObTableClient> pair : OB_TABLE_CLIENT_INSTANCE.entrySet()) {
+                pair.getValue().close();
+            }
+        }
+        catch (Exception e) {
+            throw new IOException("fail to close tableClient" , e);
+        }
         OB_TABLE_CLIENT_INSTANCE.clear();
     }
 

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
@@ -128,6 +128,10 @@ public class ObTableClientManager {
         return OB_TABLE_CLIENT_INSTANCE.get(obTableClientKey);
     }
 
+    public static void clear() {
+        OB_TABLE_CLIENT_INSTANCE.clear();
+    }
+
     public static class ObTableClientKey {
         private String     paramUrl;
         private String     fullUserName;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Patch relative bugfix commits from 2.x to master. Correctly close OHTable when finished.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Correctly close ObTableClient used in OHTable and clear ObTableClient cache stored in ObTableClientManger.