### PR TITLE
Fix the error caused by putting a KeyValue with a delete type

### DIFF
--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -5109,6 +5109,52 @@ public abstract class HTableTestBase extends HTableMultiCFTestBase {
     }
 
     @Test
+    public void testHbasePutDeleteCell() throws Exception {
+        final byte[] rowKey = Bytes.toBytes("12345");
+        final byte[] family = Bytes.toBytes("family1");
+
+        Put put = new Put(rowKey);
+        put.add(family, Bytes.toBytes("A"), Bytes.toBytes("a"));
+        put.add(family, Bytes.toBytes("B"), Bytes.toBytes("b"));
+        put.add(family, Bytes.toBytes("C"), Bytes.toBytes("c"));
+        put.add(family, Bytes.toBytes("D"), Bytes.toBytes("d"));
+        hTable.put(put);
+        // get row back and assert the values
+        Get get = new Get(rowKey);
+        get.addFamily(family);
+        Result result = hTable.get(get);
+        assertTrue("Column A value should be a",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("A"))).equals("a"));
+        assertTrue("Column B value should be b",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("B"))).equals("b"));
+        assertTrue("Column C value should be c",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("C"))).equals("c"));
+        assertTrue("Column D value should be d",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("D"))).equals("d"));
+        // put the same row again with C column deleted
+        put = new Put(rowKey);
+        put.add(family, Bytes.toBytes("A"), Bytes.toBytes("a1"));
+        put.add(family, Bytes.toBytes("B"), Bytes.toBytes("b1"));
+        KeyValue marker = new KeyValue(rowKey, family, Bytes.toBytes("C"),
+            HConstants.LATEST_TIMESTAMP, KeyValue.Type.DeleteColumn);
+        put.add(family, Bytes.toBytes("D"), Bytes.toBytes("d1"));
+        put.add(marker);
+        hTable.put(put);
+        // get row back and assert the values
+        get = new Get(rowKey);
+        get.addFamily(family);
+        result = hTable.get(get);
+        assertTrue("Column A value should be a1",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("A"))).equals("a1"));
+        assertTrue("Column B value should be b1",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("B"))).equals("b1"));
+        System.out.println(result.getValue(family, Bytes.toBytes("C")));
+        assertTrue("Column C should not exist", result.getValue(family, Bytes.toBytes("C")) == null);
+        assertTrue("Column D value should be d1",
+            Bytes.toString(result.getValue(family, Bytes.toBytes("D"))).equals("d1"));
+    }
+
+    @Test
     public void testCellTTL() throws Exception {
         String key1 = "key1";
         String column1 = "cf1";

--- a/src/test/java/com/alipay/oceanbase/hbase/util/ObHTableTestUtil.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/util/ObHTableTestUtil.java
@@ -70,7 +70,7 @@ public class ObHTableTestUtil {
 
     public static void prepareClean(List<String> tableGroupList) throws Exception {
         for (String tableGroup : tableGroupList) {
-            tableNameList.addAll(getOTableNameList(tableGroup));
+            tableNameList.addAll(getOHTableNameList(tableGroup));
         }
     }
 
@@ -120,30 +120,30 @@ public class ObHTableTestUtil {
         return new OHTableClient(tableName, newConfiguration());
     }
 
-    static public List<String> getOTableNameList(String tableGroup) throws IOException {
-            // 读取建表语句
-            List<String> res = new LinkedList<>();
-            String sql = new String(Files.readAllBytes(Paths.get(NativeHBaseUtil.SQL_PATH)));
-            String[] sqlList = sql.split(";");
-            Map<String, HTableDescriptor> tableMap = new LinkedHashMap<>();
-            for (String singleSql : sqlList) {
-                String realTableName;
-                if (singleSql.contains("CREATE TABLE ")) {
-                    singleSql.trim();
-                    String[] splits = singleSql.split(" ");
-                    String tableGroupName = splits[2].substring(1, splits[2].length() - 1);
-                    if (tableGroupName.contains(":")) {
-                        String[] tmpStr = tableGroupName.split(":", 2);
-                        tableGroupName = tmpStr[1];
-                    }
-                    realTableName = tableGroupName.split("\\$", 2)[0];
-                    if (realTableName.equals(tableGroup)) {
-                        res.add(tableGroupName);
-                    }
+    static public List<String> getOHTableNameList(String tableGroup) throws IOException {
+        // 读取建表语句
+        List<String> res = new LinkedList<>();
+        String sql = new String(Files.readAllBytes(Paths.get(NativeHBaseUtil.SQL_PATH)));
+        String[] sqlList = sql.split(";");
+        Map<String, HTableDescriptor> tableMap = new LinkedHashMap<>();
+        for (String singleSql : sqlList) {
+            String realTableName;
+            if (singleSql.contains("CREATE TABLE ")) {
+                singleSql.trim();
+                String[] splits = singleSql.split(" ");
+                String tableGroupName = splits[2].substring(1, splits[2].length() - 1);
+                if (tableGroupName.contains(":")) {
+                    String[] tmpStr = tableGroupName.split(":", 2);
+                    tableGroupName = tmpStr[1];
+                }
+                realTableName = tableGroupName.split("\\$", 2)[0];
+                if (realTableName.equals(tableGroup)) {
+                    res.add(tableGroupName);
                 }
             }
-            return res;
         }
+        return res;
+    }
 
     static public Connection getConnection() {
         try {


### PR DESCRIPTION

## Summary
When putting a KeyValue with a delete type, the current behavior is to directly insert the value, whereas it should actually be treated as a delete operation.



## Solution Description
Modify the logic of acquiring mutate to use key-value type for judgment.
