### PR TITLE
fix different exception type from origin hbase

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hbase.client.coprocessor.Batch;
 import org.apache.hadoop.hbase.filter.*;
 import org.apache.hadoop.hbase.io.TimeRange;
 import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
+import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.util.Threads;
@@ -1342,8 +1343,9 @@ public class OHTable implements HTableInterface {
                                                 + mutation.getClass().getName());
             }
             checkFamilyViolationForOneFamily(mutation.getFamilyCellMap().keySet());
-            checkArgument(Arrays.equals(family, mutation.getFamilyCellMap().firstEntry().getKey()),
-                "mutation family is not equal check family");
+            if (!Arrays.equals(family, mutation.getFamilyCellMap().firstEntry().getKey())) {
+                throw new NoSuchColumnFamilyException("mutation family is not equal check family");
+            }
         }
         byte[] filterString = buildCheckAndMutateFilterString(family, qualifier, compareOp, value);
         ObHTableFilter filter = buildObHTableFilter(filterString, null, 1, qualifier);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
The exception type from our client when the family is not matched using checkAndMutate is different from original HBase. To accomplish high compatibility, adapt the exception type to original HBase.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Change exception type from IllegalArgumentException to NoSuchColumnFamilyException.