### PR TITLE
Compatbile to original hbase checkandmutate different row operations

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -1324,8 +1324,6 @@ public class OHTable implements HTableInterface {
                                      RowMutations rowMutations) throws Exception {
         checkArgument(row != null, "row is null");
         checkArgument(isNotBlank(Bytes.toString(family)), "family is blank");
-        checkArgument(Bytes.equals(row, rowMutations.getRow()),
-            "mutation row is not equal check row");
         checkArgument(!rowMutations.getMutations().isEmpty(), "mutation is empty");
         List<Mutation> mutations = rowMutations.getMutations();
         // only one family operation is allowed

--- a/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/HTableTestBase.java
@@ -4761,7 +4761,7 @@ public abstract class HTableTestBase extends HTableMultiCFTestBase {
 
     @Test
     public void testCheckAndMutationIllegal() throws IOException {
-        // check and mute 只支持一行操作
+        // checkAndPut 只支持一行操作
         try {
             Put put = new Put("key_7".getBytes());
             put.add("family1".getBytes(), "column1_1".getBytes(), "value2".getBytes());
@@ -4770,20 +4770,6 @@ public abstract class HTableTestBase extends HTableMultiCFTestBase {
             fail();
         } catch (IOException e) {
             Assert.assertTrue(e.getMessage().contains("doesn't match the original one"));
-        }
-
-        // check and mute 只支持一行操作
-        try {
-            RowMutations mutations = new RowMutations("key_7".getBytes());
-            Put put = new Put("key_7".getBytes());
-            put.add("family1".getBytes(), "column1_1".getBytes(), "value2".getBytes());
-            mutations.add(put);
-            boolean ret = hTable.checkAndMutate("key_8".getBytes(), "family1".getBytes(),
-                "column1_1".getBytes(), CompareFilter.CompareOp.EQUAL, "value1".getBytes(),
-                mutations);
-            fail();
-        } catch (IOException e) {
-            Assert.assertTrue(e.getMessage().contains("mutation row is not equal check row error"));
         }
 
         try {
@@ -5220,7 +5206,7 @@ public abstract class HTableTestBase extends HTableMultiCFTestBase {
         try {
             tryPut(hTable, errorPut);
         } catch (Exception e) {
-            assertTrue(e.getCause().getCause().toString().contains("Unknown column 'TTL'"));
+            assertTrue(e.getCause().toString().contains("Unknown column 'TTL'"));
         }
         // test put and get
         tryPut(hTable, put1);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
CheckAndMutate in original HBase can operate RowMutations with different row from the checkRow in CheckAndMutate, but old version of OBKV-Hbase client cannot. CheckAndPut and CheckAndDelete cannot operate different row operations from the checkRow, so CheckAndPut and CheckAndDelete will check whether the row is the same.

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
