### PR TITLE
Fix multi-cf null qualifier

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
@@ -35,10 +35,6 @@ public class OHBaseFuncUtils {
             throw new RuntimeException("Cannot get family name");
         }
         byte[] family = Arrays.copyOfRange(qualifier, 0, familyLen);
-        int qualifierLen = qualifier.length - familyLen - 1;
-        if (qualifierLen <= 0) {
-            throw new RuntimeException("Cannot get qualifier name");
-        }
         byte[] newQualifier = Arrays.copyOfRange(qualifier, familyLen + 1, qualifier.length);
         return new byte[][] { family, newQualifier };
     }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Original HBase supports null qualifier and display it as empty byte array. To adapt this, OBKV-HBase need to support empty result retrieved from null qualifier and store as empty byte array.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
