### PR TITLE
Fix put comp conn

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -2238,11 +2238,9 @@ public class OHTable implements HTableInterface {
 
     private BufferedMutator getBufferedMutator() throws IOException {
         if (this.mutator == null) {
-            this.mutator = new OHBufferedMutatorImpl(
-                    this.configuration,
-                    new BufferedMutatorParams(TableName.valueOf(this.tableNameString))
-                            .pool(this.executePool).writeBufferSize(this.writeBufferSize)
-                            .maxKeyValueSize(this.maxKeyValueSize), this);
+            this.mutator = new OHBufferedMutatorImpl(this.configuration, new BufferedMutatorParams(
+                TableName.valueOf(this.tableNameString)).pool(this.executePool)
+                .writeBufferSize(this.writeBufferSize).maxKeyValueSize(this.maxKeyValueSize), this);
         }
         return this.mutator;
     }

--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -123,13 +123,6 @@ public class OHTable implements HTableInterface {
     private boolean               closeClientOnClose     = true;
 
     /**
-     * If the connection this ObTable obtains is created by the ObTable itself,
-     * should set true and close the connection when this ObTable closes;
-     * otherwise set false
-     */
-    private final boolean         cleanupConnectionOnClose;
-
-    /**
      * when the operationExecuteInPool is true the <code>Get</code>
      * will be executed in the pool.
      */
@@ -167,11 +160,6 @@ public class OHTable implements HTableInterface {
     private int                   scannerTimeout;
 
     /**
-     * the connection to obtain bufferedMutator for Put operations
-     */
-    private OHConnectionImpl      connection;
-
-    /**
      * the bufferedMutator to execute Puts
      */
     private OHBufferedMutatorImpl mutator;
@@ -199,8 +187,6 @@ public class OHTable implements HTableInterface {
         this.configuration = configuration;
         this.tableName = tableName.getBytes();
         this.tableNameString = tableName;
-        this.connection = (OHConnectionImpl) ConnectionFactory.createConnection(configuration);
-        this.cleanupConnectionOnClose = true;
 
         int maxThreads = configuration.getInt(HBASE_HTABLE_PRIVATE_THREADS_MAX,
             DEFAULT_HBASE_HTABLE_PRIVATE_THREADS_MAX);
@@ -258,8 +244,6 @@ public class OHTable implements HTableInterface {
         this.configuration = configuration;
         this.tableName = tableName;
         this.tableNameString = Bytes.toString(tableName);
-        this.connection = (OHConnectionImpl) ConnectionFactory.createConnection(configuration);
-        this.cleanupConnectionOnClose = true;
         this.executePool = executePool;
         this.cleanupPoolOnClose = false;
         OHConnectionConfiguration ohConnectionConf = new OHConnectionConfiguration(configuration);
@@ -296,7 +280,6 @@ public class OHTable implements HTableInterface {
         this.tableNameString = Bytes.toString(tableName);
         this.cleanupPoolOnClose = false;
         this.closeClientOnClose = false;
-        this.cleanupConnectionOnClose = false;
         this.executePool = executePool;
         this.obTableClient = obTableClient;
         this.configuration = HBaseConfiguration.create();
@@ -314,8 +297,6 @@ public class OHTable implements HTableInterface {
         this.tableNameString = Bytes.toString(tableName.getName());
         this.configuration = connection.getConfiguration();
         this.executePool = executePool;
-        this.connection = (OHConnectionImpl) connection;
-        this.cleanupConnectionOnClose = false;
         if (executePool == null) {
             int maxThreads = configuration.getInt(HBASE_HTABLE_PRIVATE_THREADS_MAX,
                 DEFAULT_HBASE_HTABLE_PRIVATE_THREADS_MAX);
@@ -1531,11 +1512,6 @@ public class OHTable implements HTableInterface {
         if (cleanupPoolOnClose) {
             executePool.shutdown();
         }
-        if (cleanupConnectionOnClose) {
-            if (this.connection != null) {
-                this.connection.close();
-            }
-        }
         this.isClosed = true;
     }
 
@@ -2262,10 +2238,11 @@ public class OHTable implements HTableInterface {
 
     private BufferedMutator getBufferedMutator() throws IOException {
         if (this.mutator == null) {
-            this.mutator = (OHBufferedMutatorImpl) this.connection.getBufferedMutator(
-                new BufferedMutatorParams(TableName.valueOf(this.tableNameString))
-                    .pool(this.executePool).writeBufferSize(this.writeBufferSize)
-                    .maxKeyValueSize(this.maxKeyValueSize), this);
+            this.mutator = new OHBufferedMutatorImpl(
+                    this.configuration,
+                    new BufferedMutatorParams(TableName.valueOf(this.tableNameString))
+                            .pool(this.executePool).writeBufferSize(this.writeBufferSize)
+                            .maxKeyValueSize(this.maxKeyValueSize), this);
         }
         return this.mutator;
     }

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
@@ -18,6 +18,7 @@
 package com.alipay.oceanbase.hbase.util;
 
 import com.alipay.oceanbase.hbase.OHTable;
+import com.alipay.oceanbase.rpc.exception.ObTableUnexpectedException;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableBatchOperation;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
@@ -85,6 +86,30 @@ public class OHBufferedMutatorImpl implements BufferedMutator {
         } else {
             this.ohTable = new OHTable(tableName, ohConnection, connectionConfig, pool);
         }
+    }
+
+    public OHBufferedMutatorImpl(Configuration conf, BufferedMutatorParams params,
+                                 OHTable ohTable) throws IOException {
+        // create an OHTable object to do batch work
+        if (ohTable == null) {
+            throw new ObTableUnexpectedException("The ohTable is null.");
+        }
+        this.ohTable = ohTable;
+        // init params in OHBufferedMutatorImpl
+        this.tableName = params.getTableName();
+        this.conf = conf;
+        this.listener = params.getListener();
+
+        OHConnectionConfiguration connectionConfig = new OHConnectionConfiguration(conf);
+        this.pool = params.getPool();
+        this.rpcTimeout = connectionConfig.getRpcTimeout();
+        this.operationTimeout = connectionConfig.getOperationTimeout();
+
+        this.writeBufferSize = params.getWriteBufferSize() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
+                .getWriteBufferSize() : connectionConfig.getWriteBufferSize();
+        this.maxKeyValueSize = params.getMaxKeyValueSize() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
+                .getMaxKeyValueSize() : connectionConfig.getMaxKeyValueSize();
+
     }
 
     @Override

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
@@ -88,8 +88,11 @@ public class OHBufferedMutatorImpl implements BufferedMutator {
         }
     }
 
-    public OHBufferedMutatorImpl(Configuration conf, BufferedMutatorParams params,
-                                 OHTable ohTable) throws IOException {
+    /**
+     * only used for OHTable get bufferedMutator
+     * */
+    public OHBufferedMutatorImpl(Configuration conf, BufferedMutatorParams params, OHTable ohTable)
+                                                                                                   throws IOException {
         // create an OHTable object to do batch work
         if (ohTable == null) {
             throw new ObTableUnexpectedException("The ohTable is null.");
@@ -106,9 +109,9 @@ public class OHBufferedMutatorImpl implements BufferedMutator {
         this.operationTimeout = connectionConfig.getOperationTimeout();
 
         this.writeBufferSize = params.getWriteBufferSize() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
-                .getWriteBufferSize() : connectionConfig.getWriteBufferSize();
+            .getWriteBufferSize() : connectionConfig.getWriteBufferSize();
         this.maxKeyValueSize = params.getMaxKeyValueSize() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
-                .getMaxKeyValueSize() : connectionConfig.getMaxKeyValueSize();
+            .getMaxKeyValueSize() : connectionConfig.getMaxKeyValueSize();
 
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
To use bufferedMutator to operate Put, users must set connection configuration to our connection params if they would like to use OBKV-HBase client, which may affect too much the old execution path. To fix this, this version does not use our connection to create bufferedMutator in OHTable but to directly use new constructor to create.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
