### PR TITLE
fix incrment invalid value throws different exception from original hbase

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -32,6 +32,7 @@ import com.alipay.oceanbase.rpc.mutation.BatchOperation;
 import com.alipay.oceanbase.rpc.mutation.result.BatchOperationResult;
 import com.alipay.oceanbase.rpc.mutation.result.MutationResult;
 import com.alipay.oceanbase.rpc.protocol.payload.ObPayload;
+import com.alipay.oceanbase.rpc.protocol.payload.ResultCodes;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.ObObj;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.ObRowKey;
 import com.alipay.oceanbase.rpc.protocol.payload.impl.execute.*;
@@ -1429,7 +1430,13 @@ public class OHTable implements HTableInterface {
             return new Result(keyValues);
         } catch (Exception e) {
             logger.error(LCD.convert("01-00007"), tableNameString, e);
-            throw new IOException("increment table " + tableNameString + " error.", e);
+            if (e instanceof ObTableException &&
+                    ((ObTableException) e).getErrorCode() == ResultCodes.OB_KV_HBASE_INCR_FIELD_IS_NOT_LONG.errorCode) {
+                String errMsg = OHBaseFuncUtils.generateIncrFieldErrMsg(e.getMessage());
+                throw new DoNotRetryIOException(errMsg, e);
+            } else {
+                throw new IOException("increment table " + tableNameString + " error.", e);
+            }
         }
     }
 
@@ -1473,7 +1480,13 @@ public class OHTable implements HTableInterface {
             return Bytes.toLong((byte[]) queryResult.getPropertiesRows().get(0).get(3).getValue());
         } catch (Exception e) {
             logger.error(LCD.convert("01-00007"), tableNameString, e);
-            throw new IOException("increment table " + tableNameString + " error.", e);
+            if (e instanceof ObTableException
+                && ((ObTableException) e).getErrorCode() == ResultCodes.OB_KV_HBASE_INCR_FIELD_IS_NOT_LONG.errorCode) {
+                String errMsg = OHBaseFuncUtils.generateIncrFieldErrMsg(e.getMessage());
+                throw new DoNotRetryIOException(errMsg, e);
+            } else {
+                throw new IOException("increment table " + tableNameString + " error.", e);
+            }
         }
     }
 

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
@@ -21,6 +21,8 @@ import org.apache.hadoop.classification.InterfaceAudience;
 
 import java.util.Arrays;
 
+import static java.lang.String.format;
+
 @InterfaceAudience.Private
 public class OHBaseFuncUtils {
     public static byte[][] extractFamilyFromQualifier(byte[] qualifier) throws Exception {
@@ -37,5 +39,14 @@ public class OHBaseFuncUtils {
         byte[] family = Arrays.copyOfRange(qualifier, 0, familyLen);
         byte[] newQualifier = Arrays.copyOfRange(qualifier, familyLen + 1, qualifier.length);
         return new byte[][] { family, newQualifier };
+    }
+
+    public static String generateIncrFieldErrMsg(String errMsg) {
+        // [-10516][OB_KV_HBASE_INCR_FIELD_IS_NOT_LONG][When invoking the Increment interface, only HBase cells with a length of 8 can be converted to int64_t. the current length of the HBase cell is '4'.][ip:port][trace_id]
+        int start = errMsg.indexOf('\'');
+        int stop = errMsg.lastIndexOf('\'');
+        String errByte = errMsg.substring(start + 1, stop);
+        errMsg = format("Field is not a long, it's %s bytes wide", errByte);
+        return errMsg;
     }
 }


### PR DESCRIPTION

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Increment and IncrementColumnValue will throw different type of exception from the original hbase when encounters non-long values.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
