### PR TITLE
Set synchronized to bufferedMutator close to match original hbase2.x

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
@@ -312,7 +312,7 @@ public class OHBufferedMutatorImpl implements BufferedMutator {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (closed) {
             return;
         }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Set close() as synchronized in bufferedMutator to match original hbase 2.x bufferedMutator.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
