### PR TITLE
fix getScanners dist execute

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -139,7 +139,7 @@ public class OHTable implements HTableInterface {
     /**
      * the buffer of put request
      */
-    private final ArrayList<Put> writeBuffer            = new ArrayList<Put>();
+    private final ArrayList<Put>  writeBuffer            = new ArrayList<Put>();
     /**
      * when the put request reach the write buffer size the do put will
      * flush commits automatically
@@ -1080,13 +1080,13 @@ public class OHTable implements HTableInterface {
 
                         request = buildObTableQueryAsyncRequest(obTableQuery,
                             getTargetTableName(tableNameString));
+                        request.setAllowDistributeScan(false);
                         String phyTableName = obTableClient.getPhyTableNameFromTableGroup(
                             request.getObTableQueryRequest(), tableNameString);
                         List<Partition> partitions = obTableClient.getPartition(phyTableName, false);
                         for (Partition partition : partitions) {
                             request.getObTableQueryRequest().setTableQueryPartId(
                                 partition.getPartId());
-                            request.setAllowDistributeScan(false);
                             clientQueryAsyncStreamResult = (ObTableClientQueryAsyncStreamResult) obTableClient
                                 .execute(request);
                             ClientStreamScanner clientScanner = new ClientStreamScanner(
@@ -1106,6 +1106,7 @@ public class OHTable implements HTableInterface {
                             String targetTableName = getTargetTableName(tableNameString, Bytes.toString(family),
                                     configuration);
                             request = buildObTableQueryAsyncRequest(obTableQuery, targetTableName);
+                            request.setAllowDistributeScan(false);
                             List<Partition> partitions = obTableClient
                                 .getPartition(targetTableName, false);
                             for (Partition partition : partitions) {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Set AllowDistributeScan to false so that the actual tablet ID can be filled in on the request during subsequent calls to query, preventing data duplication.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
