### PR TITLE
fix [multi cf] put random binary column

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -2176,14 +2176,14 @@ public class OHTable implements HTableInterface {
                     for (KeyValue kv : keyValueList) {
                         singleOpResultNum++;
                         if (isTableGroup) {
-                            byte [] old_qualifier = kv.getQualifier();
-                            byte [] new_qualifier = new byte[family.length + 1/* length of "." */ + old_qualifier.length];
-                            System.arraycopy(family, 0, new_qualifier, 0, family.length);
-                            new_qualifier[family.length] = 0x2E; // 0x2E in utf-8 is "."
-                            System.arraycopy(old_qualifier, 0, new_qualifier, family.length +1,old_qualifier.length );
-                            KeyValue new_kv = modifyQualifier(kv, new_qualifier);
+                            byte[] oldQualifier = kv.getQualifier();
+                            byte[] newQualifier = new byte[family.length + 1/* length of "." */ + oldQualifier.length];
+                            System.arraycopy(family, 0, newQualifier, 0, family.length);
+                            newQualifier[family.length] = 0x2E; // 0x2E in utf-8 is "."
+                            System.arraycopy(oldQualifier, 0, newQualifier, family.length +1, oldQualifier.length );
+                            KeyValue newKV = modifyQualifier(kv, newQualifier);
                             batch
-                                .addOperation(buildMutation(new_kv, INSERT_OR_UPDATE, true, put.getTTL()));
+                                .addOperation(buildMutation(newKV, INSERT_OR_UPDATE, true, put.getTTL()));
                         } else {
                             batch.addOperation(buildMutation(kv, INSERT_OR_UPDATE, false, put.getTTL()));
                         }

--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -2176,9 +2176,12 @@ public class OHTable implements HTableInterface {
                     for (KeyValue kv : keyValueList) {
                         singleOpResultNum++;
                         if (isTableGroup) {
-                            KeyValue new_kv = modifyQualifier(kv,
-                                (Bytes.toString(family) + "." + Bytes.toString(kv.getQualifier()))
-                                    .getBytes());
+                            byte [] old_qualifier = kv.getQualifier();
+                            byte [] new_qualifier = new byte[family.length + 1/* length of "." */ + old_qualifier.length];
+                            System.arraycopy(family, 0, new_qualifier, 0, family.length);
+                            new_qualifier[family.length] = 0x2E; // 0x2E in utf-8 is "."
+                            System.arraycopy(old_qualifier, 0, new_qualifier, family.length +1,old_qualifier.length );
+                            KeyValue new_kv = modifyQualifier(kv, new_qualifier);
                             batch
                                 .addOperation(buildMutation(new_kv, INSERT_OR_UPDATE, true, put.getTTL()));
                         } else {


### PR DESCRIPTION
qualifier unexpectedly expends its original size

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary

### test code:
```java 
            byte[] Rowkey = generateRandomValue(1024);
            byte[] Column = generateRandomValue(256);
            byte[] Value = generateRandomValue(1024);
            long timestamp = System.currentTimeMillis();
            Put put = new Put(Rowkey);
            Get get = new Get(toBytes(key));
            for (String tableName : entry.getValue()) {
                String family = getColumnFamilyName(tableName);
                put.addColumn(family.getBytes(), Column, timestamp, Value);
                get.addColumn(family.getBytes(), Column);
            }
            hTable.put(put);
```

```
Caused by: com.alipay.oceanbase.rpc.exception.ObTableException: [-5167][OB_ERR_DATA_TOO_LONG][Data too long for column 'Q' at row 0][11.161.204.224:6901][Y1F5081EF9E2B3-0000000000000006]
```

## Solution Description
In UTF-8 encoding, not all byte values are valid. The range 0x80~0xBF represents invalid values. When decoded into characters, these invalid byte values are replaced with a 3-byte character and re-encoded into 3 bytes. As a result, when an invalid byte value is converted to a string and then back to bytes using toString().getBytes(), it expands by 2 bytes. This expansion can cause the "Data too long for column 'Q' at row 0" error when inserting 256 random binary values into the column Q. 