### PR TITLE
change rpc connect timeout to 1s to adapt disaster recovery

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/constants/OHConstants.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/constants/OHConstants.java
@@ -155,4 +155,5 @@ public final class OHConstants {
 
     public static final int      DEFAULT_SOCKET_TIMEOUT                      = 20000;                                   // 20 seconds
 
+    public static final int      DEFAULT_SOCKET_TIMEOUT_CONNECT              = 1000;
 }

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
@@ -30,7 +30,6 @@ import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFE
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFER_PERIODIC_FLUSH_TIMERTICK_MS;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFER_PERIODIC_FLUSH_TIMERTICK_MS_DEFAULT;
 import static org.apache.commons.lang.StringUtils.isBlank;
-import static org.apache.hadoop.hbase.ipc.RpcClient.DEFAULT_SOCKET_TIMEOUT_CONNECT;
 import static org.apache.hadoop.hbase.ipc.RpcClient.SOCKET_TIMEOUT_CONNECT;
 
 @InterfaceAudience.Private
@@ -93,7 +92,7 @@ public class OHConnectionConfiguration {
             rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT_CONNECT, DEFAULT_SOCKET_TIMEOUT_CONNECT);
         } else {
             if (conf.get(SOCKET_TIMEOUT) != null) {
-                rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
+                rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT_CONNECT);
             } else {
                 rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT_CONNECT,
                     DEFAULT_SOCKET_TIMEOUT_CONNECT);


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
This change is to adapt the disaster recovery situation. The old rpc connect timeout causes long recovery duration after one of servers going down. This version of hbase client changes the rpc connect timeout from 10s to 1s, which is the same as obkv-table client rpc connect timeout.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
Changes the rpc connect timeout from 10s to 1s.