### PR TITLE
add hash-like partition case for region locator

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHTableDescriptorExecutor.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHTableDescriptorExecutor.java
@@ -10,7 +10,6 @@ import com.alipay.oceanbase.rpc.meta.ObTableRpcMetaType;
 import org.apache.hadoop.hbase.HColumnDescriptor;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
-import sun.font.SunFontManager;
 
 import java.io.IOException;
 import java.util.HashMap;

--- a/src/test/java/com/alipay/oceanbase/hbase/OHConnectionTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHConnectionTest.java
@@ -22,6 +22,7 @@ import com.alipay.oceanbase.hbase.util.ObHTableTestUtil;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -30,6 +31,7 @@ import org.junit.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
@@ -989,6 +991,21 @@ public class OHConnectionTest {
                 }
             });
         }
+    }
+    @Test
+    public void testKeyPartitionWithRegionLocator() throws IOException {
+        final String tableNameStr = "test_multi_cf";
+        final TableName tableName = TableName.valueOf(tableNameStr);
+        final Configuration conf = ObHTableTestUtil.newConfiguration();
+        connection = ConnectionFactory.createConnection(conf);
+        hTable = connection.getTable(tableName);
+        RegionLocator locator = connection.getRegionLocator(tableName);
+        byte[][] startKeys = locator.getStartKeys();
+        byte[][] endKeys = locator.getEndKeys();
+        Assert.assertEquals("Should have 1 region", 1, startKeys.length);
+        Assert.assertEquals("Should have 1 region", 1, endKeys.length);
+        Assert.assertEquals(startKeys[0], endKeys[0]);
+        Assert.assertEquals(startKeys[0], HConstants.EMPTY_BYTE_ARRAY);
     }
 
     @Test

--- a/src/test/java/com/alipay/oceanbase/hbase/OHTableAdminInterfaceTest.java
+++ b/src/test/java/com/alipay/oceanbase/hbase/OHTableAdminInterfaceTest.java
@@ -356,7 +356,7 @@ public class OHTableAdminInterfaceTest {
         // enable an enabled table
         thrown = assertThrows(IOException.class,
                 () -> {
-                    admin.disableTable(TableName.valueOf("n1", "test");
+                    admin.disableTable(TableName.valueOf("n1", "test"));
                 });
         assertTrue(thrown.getCause() instanceof ObTableException);
         Assert.assertEquals(ResultCodes.OB_KV_TABLE_NOT_ENABLED.errorCode, ((ObTableException) thrown.getCause()).getErrorCode());


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Region locator uses hash-like partitioning; returns (min, max) from key partition table

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
