### PR TITLE
Use table fastxml:jackson, exclude hbase-client fastxml:jaskson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,10 @@
                     <artifactId>jersey-json</artifactId>
                     <groupId>com.sun.jersey</groupId>
                 </exclusion>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -197,11 +201,6 @@
             <artifactId>logback-classic</artifactId>
             <version>1.2.12</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.19.0</version>
         </dependency>
     </dependencies>
     <repositories>


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Use table fastxml:jackson, exclude hbase-client fastxml:jaskson dependency.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
