### PR TITLE
Fix tableExists namespace not exists throw exception

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHAdmin.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHAdmin.java
@@ -80,7 +80,7 @@ public class OHAdmin implements Admin {
                 int errCode = ((ObTableException) cause).getErrorCode();
                 // if the original cause is database_not_exist, means namespace in tableName does not exist
                 // for HBase, namespace not exist will not throw exceptions but will return false
-                if (errCode == ResultCodes.OB_ERR_BAD_DATABASE.errorCode) {
+                if (errCode == ResultCodes.OB_KV_HBASE_NAMESPACE_NOT_FOUND.errorCode) {
                     return false;
                 }
             }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Use OB_KV_HBASE_NAMESPACE_NOT_FOUND to match the situation when namespace does not exists instead of OB_ERR_BAD_DATABASE.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
