### PR TITLE
Fix old client and odp disable to refresh tableEntry if using new server

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -78,6 +78,7 @@ import static com.alipay.oceanbase.hbase.util.TableHBaseLoggerFactory.LCD;
 import static com.alipay.oceanbase.hbase.util.TableHBaseLoggerFactory.TABLE_HBASE_LOGGER_SPACE;
 import static com.alipay.oceanbase.rpc.mutation.MutationFactory.colVal;
 import static com.alipay.oceanbase.rpc.mutation.MutationFactory.row;
+import static com.alipay.oceanbase.rpc.property.Property.RPC_OPERATION_TIMEOUT;
 import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperation.getInstance;
 import static com.alipay.oceanbase.rpc.protocol.payload.impl.execute.ObTableOperationType.*;
 import static com.alipay.sofa.common.thread.SofaThreadPoolConstants.SOFA_THREAD_POOL_LOGGING_CAPABILITY;
@@ -227,7 +228,7 @@ public class OHTable implements Table {
             this.tableNameString, ohConnectionConf));
         this.obTableClient.setRpcExecuteTimeout(ohConnectionConf.getRpcTimeout());
         this.obTableClient.setRuntimeRetryTimes(numRetries);
-        setOperationTimeout(ohConnectionConf.getOperationTimeout());
+        setOperationTimeout(ohConnectionConf.getClientOperationTimeout());
 
         finishSetUp();
     }
@@ -279,7 +280,7 @@ public class OHTable implements Table {
             this.tableNameString, ohConnectionConf));
         this.obTableClient.setRpcExecuteTimeout(ohConnectionConf.getRpcTimeout());
         this.obTableClient.setRuntimeRetryTimes(numRetries);
-        setOperationTimeout(ohConnectionConf.getOperationTimeout());
+        setOperationTimeout(ohConnectionConf.getClientOperationTimeout());
 
         finishSetUp();
     }
@@ -336,7 +337,7 @@ public class OHTable implements Table {
         this.rpcTimeout = connectionConfig.getRpcTimeout();
         this.readRpcTimeout = connectionConfig.getReadRpcTimeout();
         this.writeRpcTimeout = connectionConfig.getWriteRpcTimeout();
-        this.operationTimeout = connectionConfig.getOperationTimeout();
+        this.operationTimeout = connectionConfig.getClientOperationTimeout();
         this.operationExecuteInPool = this.configuration.getBoolean(
             HBASE_CLIENT_OPERATION_EXECUTE_IN_POOL,
             (this.operationTimeout != HConstants.DEFAULT_HBASE_CLIENT_OPERATION_TIMEOUT));
@@ -2371,6 +2372,7 @@ public class OHTable implements Table {
             resultMapSingleOp.add(singleOpResultNum);
         }
         batch.setEntityType(ObTableEntityType.HKV);
+        batch.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
         return batch;
     }
 
@@ -2431,6 +2433,7 @@ public class OHTable implements Table {
         request.setKeys(keys);
         request.setOpType(opType);
         request.setCfRows(cfRowsArray);
+        request.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
         return request;
     }
 
@@ -2474,6 +2477,7 @@ public class OHTable implements Table {
         request.setEntityType(ObTableEntityType.HKV);
         request.setTableQuery(obTableQuery);
         request.setTableName(targetTableName);
+        request.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
         return request;
     }
 
@@ -2487,6 +2491,7 @@ public class OHTable implements Table {
         asyncRequest.setEntityType(ObTableEntityType.HKV);
         asyncRequest.setTableName(targetTableName);
         asyncRequest.setObTableQueryRequest(request);
+        asyncRequest.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
         return asyncRequest;
     }
 
@@ -2501,6 +2506,7 @@ public class OHTable implements Table {
         request.setTableQueryAndMutate(queryAndMutate);
         request.setEntityType(ObTableEntityType.HKV);
         request.setReturningAffectedEntity(true);
+        request.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
         return request;
     }
 

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHAdmin.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHAdmin.java
@@ -89,7 +89,7 @@ public class OHAdmin implements Admin {
 
     @Override
     public int getOperationTimeout() {
-        return connection.getOHConnectionConfiguration().getOperationTimeout();
+        return connection.getOHConnectionConfiguration().getClientOperationTimeout();
     }
 
     @Override

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
@@ -101,4 +101,14 @@ public class OHBaseFuncUtils {
             }
         });
     }
+
+    public static boolean serverCanRetry(ObTableClient tableClient) {
+        if (tableClient.isOdpMode()) {
+            // ODP mode needs to check proxy version
+            return ObGlobal.OB_PROXY_VERSION >= ObGlobal.OB_PROXY_VERSION_4_3_6_0;
+        } else {
+            // OCP mode directly return true, server will do the check
+            return true;
+        }
+    }
 }

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBufferedMutatorImpl.java
@@ -33,7 +33,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import static com.alipay.oceanbase.rpc.util.TableClientLoggerFactory.LCD;
 
 @InterfaceAudience.Private
 public class OHBufferedMutatorImpl implements BufferedMutator {
@@ -94,7 +93,7 @@ public class OHBufferedMutatorImpl implements BufferedMutator {
                 .getRpcTimeout() : connectionConfig.getRpcTimeout());
         this.operationTimeout = new AtomicInteger(
             params.getOperationTimeout() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
-                .getOperationTimeout() : connectionConfig.getOperationTimeout());
+                .getOperationTimeout() : connectionConfig.getClientOperationTimeout());
 
         long newPeriodicFlushTimeoutMs = params.getWriteBufferPeriodicFlushTimeoutMs() != OHConnectionImpl.BUFFERED_PARAM_UNSET ? params
             .getWriteBufferPeriodicFlushTimeoutMs() : connectionConfig

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
@@ -46,7 +46,8 @@ public class OHConnectionConfiguration {
     private final int        odpPort;
     private final boolean    odpMode;
     private final long       writeBufferSize;
-    private final int        operationTimeout;
+    private final int        clientOperationTimeout;
+    private final int        serverOperationTimeout;
     private final int        metaOperationTimeout;
     private final int        scannerCaching;
     private final long       scannerMaxResultSize;
@@ -76,8 +77,10 @@ public class OHConnectionConfiguration {
         this.writeBufferSize = conf.getLong(WRITE_BUFFER_SIZE_KEY, WRITE_BUFFER_SIZE_DEFAULT);
         this.metaOperationTimeout = conf.getInt(HConstants.HBASE_CLIENT_META_OPERATION_TIMEOUT,
             HConstants.DEFAULT_HBASE_CLIENT_OPERATION_TIMEOUT);
-        this.operationTimeout = conf.getInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT,
+        this.clientOperationTimeout = conf.getInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT,
             HConstants.DEFAULT_HBASE_CLIENT_OPERATION_TIMEOUT);
+        this.serverOperationTimeout = conf.getInt(HConstants.HBASE_RPC_SHORTOPERATION_TIMEOUT_KEY,
+                HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_TIMEOUT);
         this.rpcTimeout = conf.getInt(HConstants.HBASE_RPC_TIMEOUT_KEY,
             HConstants.DEFAULT_HBASE_RPC_TIMEOUT);
         this.readRpcTimeout = conf.getInt(HConstants.HBASE_RPC_READ_TIMEOUT_KEY,
@@ -133,8 +136,12 @@ public class OHConnectionConfiguration {
         return this.metaOperationTimeout;
     }
 
-    public int getOperationTimeout() {
-        return this.operationTimeout;
+    public int getClientOperationTimeout() {
+        return this.clientOperationTimeout;
+    }
+
+    public int getServerOperationTimeout() {
+        return this.serverOperationTimeout;
     }
 
     public int getScannerCaching() {

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableBuilderBase.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableBuilderBase.java
@@ -39,7 +39,7 @@ abstract public class ObTableBuilderBase implements TableBuilder {
         }
         this.tableName = tableName;
         this.operationTimeout = tableName.isSystemTable() ? ohConnConf.getMetaOperationTimeout()
-            : ohConnConf.getOperationTimeout();
+            : ohConnConf.getClientOperationTimeout();
         this.rpcTimeout = ohConnConf.getRpcTimeout();
         this.readRpcTimeout = ohConnConf.getReadRpcTimeout();
         this.writeRpcTimeout = ohConnConf.getWriteRpcTimeout();

--- a/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/ObTableClientManager.java
@@ -32,6 +32,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import static com.alipay.oceanbase.hbase.constants.OHConstants.*;
 import static com.alipay.oceanbase.hbase.util.Preconditions.checkArgument;
+import static com.alipay.oceanbase.rpc.property.Property.RPC_OPERATION_TIMEOUT;
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 
 @InterfaceAudience.Private
@@ -86,11 +87,11 @@ public class ObTableClientManager {
             obTableClientKey.getProperties().put(property.getKey(), property.getValue());
         }
 
-        return getOrCreateObTableClient(obTableClientKey, connectionConfig.getRpcConnectTimeout());
+        return getOrCreateObTableClient(obTableClientKey, connectionConfig);
     }
 
     public static ObTableClient getOrCreateObTableClient(ObTableClientKey obTableClientKey,
-                                                         int rpcConnectTimeout) throws IOException {
+                                                         OHConnectionConfiguration connectionConfig) throws IOException {
         if (OB_TABLE_CLIENT_INSTANCE.get(obTableClientKey) == null) {
             ReentrantLock tmp = new ReentrantLock();
             ReentrantLock lock = OB_TABLE_CLIENT_LOCK.putIfAbsent(obTableClientKey, tmp);
@@ -115,7 +116,8 @@ public class ObTableClientManager {
                     }
                     obTableClient.setFullUserName(obTableClientKey.getFullUserName());
                     obTableClient.setPassword(obTableClientKey.getPassword());
-                    obTableClient.setRpcConnectTimeout(rpcConnectTimeout);
+                    obTableClient.setRpcConnectTimeout(connectionConfig.getRpcConnectTimeout());
+                    obTableClient.addProperty(RPC_OPERATION_TIMEOUT.getKey(), Integer.toString(connectionConfig.getServerOperationTimeout()));
                     obTableClient.init();
                     OB_TABLE_CLIENT_INSTANCE.put(obTableClientKey, obTableClient);
                 }
@@ -140,8 +142,8 @@ public class ObTableClientManager {
     private static void initTimeoutAndRetryTimes(ObTableClient obTableClient, OHConnectionConfiguration ohConnectionConf) {
         obTableClient.setRpcExecuteTimeout(ohConnectionConf.getRpcTimeout());
         obTableClient.setRuntimeRetryTimes(ohConnectionConf.getNumRetries());
-        obTableClient.setRuntimeMaxWait(ohConnectionConf.getOperationTimeout());
-        obTableClient.setRuntimeBatchMaxWait(ohConnectionConf.getOperationTimeout());
+        obTableClient.setRuntimeMaxWait(ohConnectionConf.getClientOperationTimeout());
+        obTableClient.setRuntimeBatchMaxWait(ohConnectionConf.getClientOperationTimeout());
     }
 
     public static class ObTableClientKey {


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix old client and odp disable to refresh tableEntry if using new server.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
