### PR TITLE
Fix performance not recovery after disaster recovery 1x

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -2287,6 +2287,7 @@ public class OHTable implements HTableInterface {
         }
         batch.setEntityType(ObTableEntityType.HKV);
         batch.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
+        batch.setNeedTabletId(OHBaseFuncUtils.needTabletId(obTableClient));
         return batch;
     }
 
@@ -2392,6 +2393,7 @@ public class OHTable implements HTableInterface {
         request.setTableQuery(obTableQuery);
         request.setTableName(targetTableName);
         request.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
+        request.setNeedTabletId(OHBaseFuncUtils.needTabletId(obTableClient));
         return request;
     }
 
@@ -2406,6 +2408,7 @@ public class OHTable implements HTableInterface {
         asyncRequest.setTableName(targetTableName);
         asyncRequest.setObTableQueryRequest(request);
         asyncRequest.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
+        asyncRequest.setNeedTabletId(OHBaseFuncUtils.needTabletId(obTableClient));
         return asyncRequest;
     }
 
@@ -2421,6 +2424,7 @@ public class OHTable implements HTableInterface {
         request.setEntityType(ObTableEntityType.HKV);
         request.setReturningAffectedEntity(true);
         request.setServerCanRetry(OHBaseFuncUtils.serverCanRetry(obTableClient));
+        request.setNeedTabletId(OHBaseFuncUtils.needTabletId(obTableClient));
         return request;
     }
 

--- a/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/OHTable.java
@@ -1110,6 +1110,7 @@ public class OHTable implements HTableInterface {
 
                         request = buildObTableQueryAsyncRequest(obTableQuery,
                             getTargetTableName(tableNameString));
+                        request.setNeedTabletId(false);
                         request.setAllowDistributeScan(false);
                         String phyTableName = obTableClient.getPhyTableNameFromTableGroup(
                             request.getObTableQueryRequest(), tableNameString);
@@ -1136,6 +1137,7 @@ public class OHTable implements HTableInterface {
                             String targetTableName = getTargetTableName(tableNameString, Bytes.toString(family),
                                     configuration);
                             request = buildObTableQueryAsyncRequest(obTableQuery, targetTableName);
+                            request.setNeedTabletId(false);
                             request.setAllowDistributeScan(false);
                             List<Partition> partitions = obTableClient
                                 .getPartition(targetTableName, false);

--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHBaseFuncUtils.java
@@ -107,4 +107,15 @@ public class OHBaseFuncUtils {
             return true;
         }
     }
+
+    public static boolean needTabletId(ObTableClient tableClient) {
+        if (tableClient.isOdpMode()) {
+            return ObGlobal.isDistributeNeedTabletIdSupport()
+                    && ObGlobal.OB_PROXY_VERSION >= ObGlobal.OB_PROXY_VERSION_4_3_6_0
+                    && tableClient.getServerCapacity().isSupportDistributedExecute();
+        } else {
+            return ObGlobal.isDistributeNeedTabletIdSupport()
+                    && tableClient.getServerCapacity().isSupportDistributedExecute();
+        }
+    }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Fix performance not recovery after disaster recovery. Add new flag to check routing tablet_id leader in server.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
