### PR TITLE
Refine login timeout

### DIFF
--- a/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
+++ b/src/main/java/com/alipay/oceanbase/hbase/util/OHConnectionConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hbase.HConstants;
 import java.util.Properties;
 
 import static com.alipay.oceanbase.hbase.constants.OHConstants.*;
+import static com.alipay.oceanbase.rpc.property.Property.RPC_CONNECT_TIMEOUT;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFER_PERIODIC_FLUSH_TIMEOUT_MS;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFER_PERIODIC_FLUSH_TIMEOUT_MS_DEFAULT;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.WRITE_BUFFER_PERIODIC_FLUSH_TIMERTICK_MS;
@@ -99,8 +100,7 @@ public class OHConnectionConfiguration {
             if (conf.get(SOCKET_TIMEOUT) != null) {
                 rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT, DEFAULT_SOCKET_TIMEOUT);
             } else {
-                rpcConnectTimeout = conf.getInt(SOCKET_TIMEOUT_CONNECT,
-                    DEFAULT_SOCKET_TIMEOUT_CONNECT);
+                rpcConnectTimeout = RPC_CONNECT_TIMEOUT.getDefaultInt(); // use table default value
             }
         }
         this.rpcConnectTimeout = rpcConnectTimeout;


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Connect timeout is too long for default value, which is 10 seconds. If not set by users, connect timeout will keep the same with the Table, which is 1 second.


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
